### PR TITLE
Remove JAR archive step (due to github limits)

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -7,7 +7,7 @@ jobs:
   gradle:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -22,9 +22,3 @@ jobs:
 
     - name: Execute Gradle build
       run: ./gradlew build
-
-    - name: Archive built jars
-      uses: actions/upload-artifact@v3
-      with:
-        name: osrs-environment-exporter-${{ matrix.os }}.jar
-        path: build/libs/osrs-environment-exporter-*.jar


### PR DESCRIPTION
Also build only on Ubuntu; now that artifacts are not archived, the
compilation processes are basically identical.