### PR TITLE
Only archive fat JARs

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -27,4 +27,4 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: osrs-environment-exporter-${{ matrix.os }}.jar
-        path: build/libs/osrs-environment-exporter-*.jar
+        path: build/libs/osrs-environment-exporter-fat-*.jar


### PR DESCRIPTION
The "slim" JARs are not runnable on their own so I think we shouldn't include them.