### PR TITLE
Simplify JVM args and use sh for ./run

### DIFF
--- a/run
+++ b/run
@@ -1,2 +1,2 @@
-#!/bin/bash
-java -XX:+SuppressFatalErrorMessage --add-opens java.base/java.lang=ALL-UNNAMED -Djavafx.verbose=true -jar ./build/libs/osrs-environment-exporter-fat-2.0.0.jar
+#!/bin/sh
+exec java --add-opens java.base/java.lang=ALL-UNNAMED -jar ./build/libs/osrs-environment-exporter-fat-2.0.0.jar "$@"


### PR DESCRIPTION
(message is copied from commit)

This removes -XX:+SuppressFatalErrorMessage, which is a flag that
prevents the hs_err_pid crash dump from being created when a fatal error
occurs. It is an unnecessary break from defaults IMO.

This also removes the verbosity flag for JavaFX, because the information
is presents to us is spammy and not especially useful.

Otherwise some changes have been made to the script itself, namely:
- Invoking under sh instead of bash (more widely available, especially
  under /bin)
- Using `exec` to remove the shell middle-man once the java program is
  launched
- Using "$@" to pass arguments from the command line to the java
  program, not that we use those