### PR TITLE
glTF export performance improvements

### DIFF
--- a/src/main/kotlin/models/glTF/Buffer.kt
+++ b/src/main/kotlin/models/glTF/Buffer.kt
@@ -5,13 +5,26 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 class Buffer(filename: String) {
     val uri = "$filename.bin"
 
-    fun getByteLength() = bytes.size
+    fun getByteLength() = byteChunks.sumOf { it.size }
 
-    // TODO: replace this with something more efficient
-    var bytes = ByteArray(0)
-        @JsonIgnore get
+    private val byteChunks = ArrayList<ByteArray>()
+
+    @JsonIgnore
+    fun getBytes(): ByteArray {
+        val finalBytes = ByteArray(getByteLength())
+        byteChunks.fold(0) { pos, chunk ->
+            System.arraycopy(chunk, 0, finalBytes, pos, chunk.size)
+            pos + chunk.size
+        }
+
+        // Might as well cache the fruit of our efforts
+        byteChunks.clear()
+        byteChunks.add(finalBytes)
+
+        return finalBytes
+    }
 
     fun addBytes(bytesToAdd: ByteArray) {
-        bytes += bytesToAdd
+        byteChunks.add(bytesToAdd)
     }
 }

--- a/src/main/kotlin/models/glTF/FloatVectorBuffer.kt
+++ b/src/main/kotlin/models/glTF/FloatVectorBuffer.kt
@@ -1,0 +1,69 @@
+package models.glTF
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.FloatBuffer
+import kotlin.math.max
+import kotlin.math.min
+
+class FloatVectorBuffer(val dims: Int) {
+    val min = FloatArray(dims) { Float.POSITIVE_INFINITY }
+    val max = FloatArray(dims) { Float.NEGATIVE_INFINITY }
+
+    private val buffer = Buffer("") // Steal our efficient byte-concat code
+    private var chunk = ByteArray(INITIAL_CAPACITY)
+    private var chunkWrapped = wrapBytes(chunk)
+
+    // Position in the vector we are writing to (e.g. 0th, 1st, or 2nd dimension)
+    private var pos = 0
+    // Total valid size of this buffer as a whole, in vectors
+    var size = 0
+        private set
+    // Total valid size of the current chunk, in vectors
+    private var innerSize = 0
+
+    private fun wrapBytes(chunk: ByteArray): FloatBuffer =
+        ByteBuffer.wrap(chunk).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer()
+
+    private fun refreshBuffer() {
+        buffer.addBytes(chunk)
+        innerSize = 0
+        chunk = ByteArray(INITIAL_CAPACITY + size * dims * BYTES_IN_A_FLOAT)
+        chunkWrapped = wrapBytes(chunk)
+    }
+
+    fun add(value: Float) {
+        chunkWrapped.put(value)
+        min[pos] = min(min[pos], value)
+        max[pos] = max(max[pos], value)
+        pos++
+        if (pos == dims) {
+            pos = 0
+            size++
+            innerSize++
+
+            if ((innerSize + 1) * dims * BYTES_IN_A_FLOAT > chunk.size) {
+                refreshBuffer()
+            }
+        }
+    }
+
+    /** Retrieve the raw bytes from this buffer.
+     *  Note that this buffer cannot be added to after this operation has taken place.
+     */
+    fun getBytes(): ByteArray {
+        if (innerSize != 0) {
+            buffer.addBytes(chunk.copyOf(innerSize * dims * BYTES_IN_A_FLOAT))
+            // Ensure no further writes succeed
+            chunk = USELESS_ARRAY
+            chunkWrapped = wrapBytes(chunk)
+        }
+        return buffer.getBytes()
+    }
+
+    companion object {
+        const val INITIAL_CAPACITY = 3 * 512 // Kind of arbitrary
+        const val BYTES_IN_A_FLOAT = 4
+        val USELESS_ARRAY = ByteArray(0)
+    }
+}

--- a/src/main/kotlin/models/glTF/FloatVectorBuffer.kt
+++ b/src/main/kotlin/models/glTF/FloatVectorBuffer.kt
@@ -16,9 +16,11 @@ class FloatVectorBuffer(val dims: Int) {
 
     // Position in the vector we are writing to (e.g. 0th, 1st, or 2nd dimension)
     private var pos = 0
+
     // Total valid size of this buffer as a whole, in vectors
     var size = 0
         private set
+
     // Total valid size of the current chunk, in vectors
     private var innerSize = 0
 
@@ -26,7 +28,11 @@ class FloatVectorBuffer(val dims: Int) {
         ByteBuffer.wrap(chunk).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer()
 
     private fun refreshBuffer() {
-        buffer.addBytes(chunk)
+        val innerBytes = innerSize * dims * BYTES_IN_A_FLOAT
+        val chunkToAdd =
+            if (innerBytes == chunk.size) chunk
+            else chunk.copyOf(innerBytes)
+        buffer.addBytes(chunkToAdd)
         innerSize = 0
         chunk = ByteArray(INITIAL_CAPACITY + size * dims * BYTES_IN_A_FLOAT)
         chunkWrapped = wrapBytes(chunk)
@@ -57,6 +63,7 @@ class FloatVectorBuffer(val dims: Int) {
             // Ensure no further writes succeed
             chunk = USELESS_ARRAY
             chunkWrapped = wrapBytes(chunk)
+            innerSize = 0
         }
         return buffer.getBytes()
     }

--- a/src/main/kotlin/models/glTF/MaterialBuffers.kt
+++ b/src/main/kotlin/models/glTF/MaterialBuffers.kt
@@ -4,16 +4,16 @@ import cache.utils.ColorPalette
 import java.awt.Color
 
 class MaterialBuffers(isTextured: Boolean) {
-    val positions = ArrayList<Float>()
-    val texcoords: ArrayList<Float>?
-    val colors: ArrayList<Float>?
+    val positions = FloatVectorBuffer(3)
+    val texcoords: FloatVectorBuffer?
+    val colors: FloatVectorBuffer?
 
     init {
         if (isTextured) {
-            texcoords = ArrayList()
+            texcoords = FloatVectorBuffer(2)
             colors = null
         } else {
-            colors = ArrayList()
+            colors = FloatVectorBuffer(3)
             texcoords = null
         }
     }

--- a/src/main/kotlin/models/glTF/glTF.kt
+++ b/src/main/kotlin/models/glTF/glTF.kt
@@ -129,7 +129,7 @@ class glTF {
         }
 
         // write buffer to files
-        File("$directory/${buffer.uri}").writeBytes(buffer.bytes)
+        File("$directory/${buffer.uri}").writeBytes(buffer.getBytes())
 
         // convert to JSON
         val mapper = ObjectMapper()


### PR DESCRIPTION
I timed the export process

Before any changes, exporting 12850 at radius 8:
```
Took 29550330805 nanoseconds
Took 25447103456 nanoseconds
Took 20830986557 nanoseconds
Took 22491631446 nanoseconds
Took 20685962938 nanoseconds
```

Median 22.5 seconds / Mean 23.8 seconds

After first commit:
```
Took 16850471357 nanoseconds
Took 14769895850 nanoseconds
Took 13297833444 nanoseconds
Took 13833327370 nanoseconds
Took 13495152207 nanoseconds
```

Median 13.8 seconds / Mean 14.4 seconds

After second commit:
```
Took 3667631632 nanoseconds
Took 2749942353 nanoseconds
Took 3241219574 nanoseconds
Took 3616193326 nanoseconds
Took 2823936507 nanoseconds
```

Median 3.24 seconds / Mean 3.22 seconds

The above timings were taken with a fairly naïve approach of just calling `System.nanoTime()` like so:

```kt
    fun exportScene() {
        val nanos = System.nanoTime()
        SceneExporter().exportSceneToFile(scene, this)
        val timeDelta = System.nanoTime() - nanos
        println("Took $timeDelta nanoseconds")
    }
```

This means that they include the timings for the full export process from start to finish, including things like copying textures.

---

So there's roughly an 86% speedup in exporting that particular region. I checked the bin and gltf files, and both are still byte-for-byte identical to the ones generated without these commits.
