### PR TITLE
Loader tweaks

### DIFF
--- a/src/main/kotlin/cache/loaders/ModelLoader.kt
+++ b/src/main/kotlin/cache/loaders/ModelLoader.kt
@@ -32,6 +32,7 @@ package cache.loaders
 
 import cache.IndexType
 import cache.definitions.ModelDefinition
+import cache.utils.readByteArray
 import cache.utils.readShortSmart
 import cache.utils.readUnsignedByte
 import cache.utils.readUnsignedShort
@@ -102,23 +103,23 @@ class ModelLoader(private val cacheLibrary: CacheLibrary) {
             if (!isNewStyleTextures) {
                 def.textureRenderTypes = ByteArray(textureCount)
             } else {
-                def.textureRenderTypes = readByteArray(stream1, textureCount)
+                def.textureRenderTypes = stream1.readByteArray(textureCount)
             }
         }
-        val vertexFlags = readByteArray(stream1, vertexCount)
+        val vertexFlags = stream1.readByteArray(vertexCount)
         if (hasFaceRenderTypes == 1) {
-            def.faceRenderTypes = readByteArray(stream1, faceCount)
+            def.faceRenderTypes = stream1.readByteArray(faceCount)
         }
-        val faceIndexCompressionTypes = readByteArray(stream1, faceCount)
+        val faceIndexCompressionTypes = stream1.readByteArray(faceCount)
         if (faceRenderPriority == 255) {
-            def.faceRenderPriorities = readByteArray(stream1, faceCount)
+            def.faceRenderPriorities = stream1.readByteArray(faceCount)
         }
         if (hasPackedTransparencyVertexGroups == 1) {
             readFaceSkins(def, stream1, faceCount)
         }
         var faceTextureFlags: ByteArray? = null
         if (oldStyleIsTextured == 1) {
-            faceTextureFlags = readByteArray(stream1, faceCount)
+            faceTextureFlags = stream1.readByteArray(faceCount)
         }
         if (hasVertexSkins == 1) {
             readVertexSkins(def, stream1, vertexCount)
@@ -127,7 +128,7 @@ class ModelLoader(private val cacheLibrary: CacheLibrary) {
             readAnimayaGroups(stream1, vertexCount)
         }
         if (hasFaceTransparencies == 1) {
-            def.faceAlphas = readByteArray(stream1, faceCount)
+            def.faceAlphas = stream1.readByteArray(faceCount)
         }
         readFaceIndexData(def, stream1, faceIndexCompressionTypes)
         if (hasFaceTextures == 1) {
@@ -416,12 +417,6 @@ class ModelLoader(private val cacheLibrary: CacheLibrary) {
         def.textureTriangleVertexIndices1 = textureTriangleVertexIndices1
         def.textureTriangleVertexIndices2 = textureTriangleVertexIndices2
         def.textureTriangleVertexIndices3 = textureTriangleVertexIndices3
-    }
-
-    private fun readByteArray(stream: ByteBuffer, length: Int): ByteArray {
-        val array = ByteArray(length)
-        stream[array]
-        return array
     }
 
     companion object {

--- a/src/main/kotlin/cache/loaders/SpriteLoader.kt
+++ b/src/main/kotlin/cache/loaders/SpriteLoader.kt
@@ -84,9 +84,7 @@ class SpriteLoader(
             val flags: Int = inputStream.readUnsignedByte()
             if (flags and FLAG_VERTICAL == 0) {
                 // read horizontally
-                for (j in 0 until dimension) {
-                    pixelPaletteIndicies[j] = inputStream.get()
-                }
+                inputStream.get(pixelPaletteIndicies)
             } else {
                 // read vertically
                 for (j in 0 until spriteWidth) {
@@ -100,9 +98,7 @@ class SpriteLoader(
             if (flags and FLAG_ALPHA != 0) {
                 if (flags and FLAG_VERTICAL == 0) {
                     // read horizontally
-                    for (j in 0 until dimension) {
-                        pixelAlphas[j] = inputStream.get()
-                    }
+                    inputStream.get(pixelAlphas)
                 } else {
                     // read vertically
                     for (j in 0 until spriteWidth) {

--- a/src/main/kotlin/cache/loaders/SpriteLoader.kt
+++ b/src/main/kotlin/cache/loaders/SpriteLoader.kt
@@ -17,7 +17,7 @@ class SpriteLoader(
             val data = cacheLibrary.data(IndexType.SPRITES.id, archive) ?: continue
             val defs = load(archive, data)
             for (def in defs) {
-                spriteDefinitionCache[def!!.id] = def
+                spriteDefinitionCache[def.id] = def
             }
         }
         cacheLibrary.index(IndexType.SPRITES.id).unCache() // free memory
@@ -27,11 +27,10 @@ class SpriteLoader(
         return spriteDefinitionCache[id]
     }
 
-    private fun load(id: Int, b: ByteArray): Array<SpriteDefinition?> {
+    private fun load(id: Int, b: ByteArray): Array<SpriteDefinition> {
         val inputStream = ByteBuffer.wrap(b)
         inputStream.position(inputStream.limit() - 2)
         val spriteCount: Int = inputStream.readUnsignedShort()
-        val sprites: Array<SpriteDefinition?> = arrayOfNulls(spriteCount)
 
         // 2 for size
         // 5 for width, height, palette length
@@ -42,24 +41,25 @@ class SpriteLoader(
         val width: Int = inputStream.readUnsignedShort()
         val height: Int = inputStream.readUnsignedShort()
         val paletteLength: Int = inputStream.readUnsignedByte() + 1
-        for (i in 0 until spriteCount) {
-            sprites[i] = SpriteDefinition()
-            sprites[i]!!.id = id
-            sprites[i]!!.frame = i
-            sprites[i]!!.maxWidth = width
-            sprites[i]!!.maxHeight = height
+        val sprites = Array(spriteCount) { i ->
+            SpriteDefinition().apply {
+                this.id = id
+                frame = i
+                maxWidth = width
+                maxHeight = height
+            }
         }
         for (i in 0 until spriteCount) {
-            sprites[i]!!.offsetX = inputStream.readUnsignedShort()
+            sprites[i].offsetX = inputStream.readUnsignedShort()
         }
         for (i in 0 until spriteCount) {
-            sprites[i]!!.offsetY = inputStream.readUnsignedShort()
+            sprites[i].offsetY = inputStream.readUnsignedShort()
         }
         for (i in 0 until spriteCount) {
-            sprites[i]!!.width = inputStream.readUnsignedShort()
+            sprites[i].width = inputStream.readUnsignedShort()
         }
         for (i in 0 until spriteCount) {
-            sprites[i]!!.height = inputStream.readUnsignedShort()
+            sprites[i].height = inputStream.readUnsignedShort()
         }
 
         // same as above + 3 bytes for each palette entry, except for the first one (which is transparent)
@@ -73,7 +73,7 @@ class SpriteLoader(
         }
         inputStream.position(0)
         for (i in 0 until spriteCount) {
-            val def: SpriteDefinition = sprites[i]!!
+            val def: SpriteDefinition = sprites[i]
             val spriteWidth: Int = def.width
             val spriteHeight: Int = def.height
             val dimension = spriteWidth * spriteHeight

--- a/src/main/kotlin/cache/utils/ByteBufferExt.kt
+++ b/src/main/kotlin/cache/utils/ByteBufferExt.kt
@@ -50,6 +50,12 @@ fun ByteBuffer.readString(): String? {
     return sb.toString()
 }
 
+fun ByteBuffer.readByteArray(length: Int): ByteArray {
+    val array = ByteArray(length)
+    get(array)
+    return array
+}
+
 private val CHARACTERS = charArrayOf(
     '\u20ac', '\u0000', '\u201a', '\u0192', '\u201e', '\u2026',
     '\u2020', '\u2021', '\u02c6', '\u2030', '\u0160', '\u2039',


### PR DESCRIPTION
Make ObjectLoader lazy (it takes about a half-second chunk of the initial load time for the objects to load). This means that they're instead loaded on-demand and will display warnings relevant to the selected region in the console rather than traversing all objects in the cache.

Additionally, reduce nullability and some other miscellaneous cleanups