### PR TITLE
Appearance improvements for About window

### DIFF
--- a/src/main/kotlin/controllers/AboutController.kt
+++ b/src/main/kotlin/controllers/AboutController.kt
@@ -3,29 +3,58 @@ package controllers
 import javafx.fxml.FXML
 import javafx.scene.control.Hyperlink
 import javafx.scene.control.Label
+import javafx.scene.layout.VBox
 import utils.LinkHandler
 import utils.PackageMetadata
 
 class AboutController {
     @FXML
-    private lateinit var lblTitle: Label
+    private lateinit var wrapper: VBox
 
     @FXML
-    private lateinit var lblVersion: Label
+    private lateinit var txtTitle: Label
+
+    @FXML
+    private lateinit var txtVersion: Label
 
     @FXML
     private lateinit var linkGitHub: Hyperlink
 
     @FXML
+    private lateinit var txtDescription: Label
+
+    @FXML
+    private lateinit var linkTrillion: Hyperlink
+
+    @FXML
+    private lateinit var linkBasedOn: Hyperlink
+
+    @FXML
+    private lateinit var linkPartyVaperFork: Hyperlink
+
+    @FXML
     fun initialize() {
         // Set Title and Version based on package metadata
         val metadata = PackageMetadata()
-        lblTitle.text = metadata.NAME
-        lblVersion.text = metadata.VERSION
+        txtTitle.text = metadata.NAME
+        txtVersion.text = metadata.VERSION
 
-        // GitHub Link handler
-        linkGitHub.setOnAction {
-            LinkHandler(linkGitHub.text).openInBrowser()
+        // bind description text and wrapper width
+        txtDescription.prefWidthProperty().bind(wrapper.widthProperty())
+
+        // link handlers
+        val links = arrayOf(
+            Link(linkGitHub, "https://github.com/ConnorDY/OSRS-Environment-Exporter"),
+            Link(linkTrillion, "https://twitter.com/TrillionStudios"),
+            Link(linkBasedOn, "https://github.com/tpetrychyn/osrs-map-editor"),
+            Link(linkPartyVaperFork, "https://github.com/partyvaper/osrs-map-editor")
+        )
+        links.forEach { link ->
+            link.control.setOnAction {
+                LinkHandler(link.link).openInBrowser()
+            }
         }
     }
+
+    private class Link(val control: Hyperlink, val link: String)
 }

--- a/src/main/resources/views/about.fxml
+++ b/src/main/resources/views/about.fxml
@@ -3,36 +3,52 @@
 <?import javafx.scene.control.Hyperlink?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
+<?import javafx.geometry.Insets?>
 
-<AnchorPane prefWidth="600.0" xmlns="http://javafx.com/javafx/11.0.1"
+<AnchorPane prefWidth="600.0" prefHeight="300.0" xmlns="http://javafx.com/javafx/11.0.1"
             xmlns:fx="http://javafx.com/fxml/1" fx:controller="controllers.AboutController">
-    <VBox prefHeight="300.0" AnchorPane.bottomAnchor="25.0" AnchorPane.leftAnchor="25.0"
+    <VBox fx:id="wrapper" AnchorPane.bottomAnchor="25.0" AnchorPane.leftAnchor="25.0"
           AnchorPane.rightAnchor="25.0" AnchorPane.topAnchor="25.0" alignment="CENTER">
-        <Label fx:id="lblTitle" text="Title" styleClass="aboutTitle"/>
+        <padding>
+            <Insets left="15.0" right="15.0"/>
+        </padding>
 
-        <Label fx:id="lblVersion" text="Version" styleClass="aboutText"/>
+        <Label fx:id="txtTitle" text="Title" styleClass="aboutTitle"/>
+
+        <Label fx:id="txtVersion" text="Version" styleClass="aboutText"/>
 
         <Hyperlink fx:id="linkGitHub" text="https://github.com/ConnorDY/OSRS-Environment-Exporter"
                    styleClass="aboutText"/>
 
         <VBox prefHeight="40"/>
 
-        <Label wrapText="true"
+        <Label fx:id="txtDescription"
                text="This application enables exporting Old School RuneScape environments so they can be used in 3D modeling programs like Blender."
+               wrapText="true"
                styleClass="aboutText"/>
 
         <VBox prefHeight="40"/>
 
         <Label text="Credits" underline="true" styleClass="aboutText"/>
 
-        <Label text="Original idea by Trillion (twitter.com/TrillionStudios)."
-               styleClass="aboutText"/>
-        <Label
-                text="Based on @tpetrychyn's OSRS Map Editor (github.com/tpetrychyn/osrs-map-editor)."
-                styleClass="aboutText"/>
-        <Label
-                text="Using changes from @partyvaper's fork (github.com/partyvaper/osrs-map-editor)."
-                styleClass="aboutText"/>
+        <HBox alignment="CENTER" styleClass="aboutText">
+            <Label text="Original idea by "/>
+            <Hyperlink fx:id="linkTrillion" text="Trillion"/>
+            <Label text="."/>
+        </HBox>
+
+        <HBox alignment="CENTER" styleClass="aboutText">
+            <Label text="Based on "/>
+            <Hyperlink fx:id="linkBasedOn" text="\@tpetrychyn's OSRS Map Editor"/>
+            <Label text="."/>
+        </HBox>
+
+        <HBox alignment="CENTER" styleClass="aboutText">
+            <Label text="Using changes from "/>
+            <Hyperlink fx:id="linkPartyVaperFork" text="\@partyvaper's fork"/>
+            <Label text="."/>
+        </HBox>
     </VBox>
 </AnchorPane>

--- a/src/main/resources/views/about.fxml
+++ b/src/main/resources/views/about.fxml
@@ -27,6 +27,7 @@
         <Label fx:id="txtDescription"
                text="This application enables exporting Old School RuneScape environments so they can be used in 3D modeling programs like Blender."
                wrapText="true"
+               prefHeight="80"
                styleClass="aboutText"/>
 
         <VBox prefHeight="40"/>


### PR DESCRIPTION
Can't figure out how to get the description text in the middle to wrap:

![image](https://user-images.githubusercontent.com/945062/180117067-0612b885-c815-4b4d-99a0-c74e315d9094.png)
