### PR TITLE
Use the correct UIManager key in NumericTextField

### DIFF
--- a/src/main/kotlin/ui/NumericTextField.kt
+++ b/src/main/kotlin/ui/NumericTextField.kt
@@ -54,7 +54,7 @@ object NumericTextField {
                     false
                 }
             control.foreground =
-                if (valid) UIManager.getColor("text") as Color
+                if (valid) UIManager.getColor("TextField.foreground") as Color
                 else Color.RED
         }
 


### PR DESCRIPTION
It so happens that in this LAF, "text" and "TextField.foreground" are the same, but apparently that is not always the case, so this is "more correct".