### PR TITLE
Automatically focus on the first input when opening windows

### DIFF
--- a/src/main/kotlin/controllers/LocationSearchController.kt
+++ b/src/main/kotlin/controllers/LocationSearchController.kt
@@ -111,6 +111,8 @@ class LocationSearchController constructor(
 
         rootPane.defaultButton = btnLoad
         pack()
+
+        txtSearchQuery.requestFocus()
     }
 
     private fun readBuiltinLocations(): ArrayList<Location> {

--- a/src/main/kotlin/controllers/RegionChooserController.kt
+++ b/src/main/kotlin/controllers/RegionChooserController.kt
@@ -106,6 +106,8 @@ class RegionChooserController constructor(
 
         rootPane.defaultButton = loadButton
         pack()
+
+        regionIdField.requestFocus()
     }
 
     private fun loadRegion(regionIdStr: String, radius: Int) {


### PR DESCRIPTION
Makes it so that the first input is automatically focused when opening the "Change Region" or "Location Search" windows.