### PR TITLE
Make CalcTileColor a little less mysterious

### DIFF
--- a/src/main/kotlin/cache/utils/Vec3F.kt
+++ b/src/main/kotlin/cache/utils/Vec3F.kt
@@ -1,0 +1,17 @@
+package cache.utils
+
+import kotlin.math.sqrt
+import kotlin.math.truncate
+
+class Vec3F(val x: Float, val y: Float, val z: Float) {
+    fun magnitude() = sqrt(x * x + y * y + z * z)
+    fun magnitudeInt() = magnitude().toInt()
+    fun dot(other: Vec3F): Float = x * other.x + y * other.y + z * other.z
+
+    /** Normalise this vector, including inaccuracies introduced by the original code */
+    fun normalizedAsInts(): Vec3F {
+        val magnitude = magnitudeInt()
+        return Vec3F(crunch(x / magnitude), crunch(y / magnitude), crunch(z / magnitude))
+    }
+    private fun crunch(x: Float): Float = truncate(256.0f * x) / 256.0f
+}


### PR DESCRIPTION
Has a few concessions to reintroduce some rounding errors present in the original code in order to not change the output

The goal here is deobfuscation rather than significant code change, and I think the goal of the function is a little clearer this way.