### PR TITLE
Allow `gradle run` (& simplify java params)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("application")
 }
 
-group = "org.example"
+group = "link.cdy"
 version = "2.1.0"
 
 repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import org.gradle.jvm.tasks.Jar
 plugins {
     kotlin("jvm") version "1.7.10"
     id("org.jlleitschuh.gradle.ktlint") version "10.3.0"
+    id("application")
 }
 
 group = "org.example"
@@ -66,6 +67,10 @@ val fatJar = task("fatJar", type = Jar::class) {
     from(configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) })
     with(tasks.jar.get() as CopySpec)
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+application {
+    mainClass.set("AppKt")
 }
 
 tasks.withType<Jar> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,11 +63,14 @@ tasks {
 
 val fatJar = task("fatJar", type = Jar::class) {
     archiveBaseName.set("${project.name}-fat")
+    from(configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) })
+    with(tasks.jar.get() as CopySpec)
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+tasks.withType<Jar> {
     manifest {
         attributes["Implementation-Version"] = archiveVersion.get()
         attributes["Main-Class"] = "AppKt"
     }
-    from(configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) })
-    with(tasks.jar.get() as CopySpec)
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/run
+++ b/run
@@ -26,4 +26,4 @@ if [ "${1#--debug}" != "$1" ]; then
     shift
 fi
 
-exec "$java" $debug_params --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.desktop/sun.awt=ALL-UNNAMED -jar ./build/libs/osrs-environment-exporter-fat-2.1.0.jar "$@"
+exec "$java" $debug_params -jar ./build/libs/osrs-environment-exporter-fat-2.1.0.jar "$@"

--- a/run.bat
+++ b/run.bat
@@ -1,2 +1,2 @@
 @echo off
-java --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.desktop/sun.awt=ALL-UNNAMED -jar ./build/libs/osrs-environment-exporter-fat-2.1.0.jar
+java -jar ./build/libs/osrs-environment-exporter-fat-2.1.0.jar


### PR DESCRIPTION
Turns out moving away from jogamp also lets us do this. Madness.