### PR TITLE
Small GLTF exporter optimisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 
 - Provide instant feedback when changing settings &ndash; [#93](https://github.com/ConnorDY/OSRS-Environment-Exporter/pull/93) @ScoreUnder
 
+### :wrench: Maintenance
+
+- Optimise glTF export a little &ndash; [#96](https://github.com/ConnorDY/OSRS-Environment-Exporter/pull/96) @ScoreUnder
+
 ## 2.1.0
 
 ### :sparkles: Enhancements

--- a/src/main/kotlin/models/glTF/Buffer.kt
+++ b/src/main/kotlin/models/glTF/Buffer.kt
@@ -1,38 +1,5 @@
 package models.glTF
 
-import com.fasterxml.jackson.annotation.JsonIgnore
-import java.nio.ByteBuffer
-
-class Buffer(filename: String) {
+class Buffer(filename: String, val byteLength: Int) {
     val uri = "$filename.bin"
-
-    fun getByteLength() = byteChunks.sumOf { it.limit() }
-
-    private val byteChunks = ArrayList<ByteBuffer>()
-
-    @JsonIgnore
-    fun getBytes(): ByteArray {
-        val buf = getByteBuffer()
-        val arr = ByteArray(buf.remaining())
-        buf.get(arr)
-        return arr
-    }
-
-    @JsonIgnore
-    fun getByteBuffer(): ByteBuffer {
-        val finalBytes = ByteBuffer.allocateDirect(getByteLength())
-        byteChunks.forEach { chunk ->
-            finalBytes.put(chunk)
-        }
-        finalBytes.flip()
-
-        // Might as well cache the fruit of our efforts
-        byteChunks.clear()
-        byteChunks.add(finalBytes.duplicate())
-        return finalBytes
-    }
-
-    fun addBytes(bytesToAdd: ByteBuffer) {
-        byteChunks.add(bytesToAdd)
-    }
 }

--- a/src/main/kotlin/models/glTF/FloatVectorBuffer.kt
+++ b/src/main/kotlin/models/glTF/FloatVectorBuffer.kt
@@ -67,7 +67,7 @@ class FloatVectorBuffer(val dims: Int) {
     /** Retrieve the raw bytes from this buffer.
      *  Note that this buffer cannot be added to after this operation has taken place.
      */
-    fun getBytes(): ByteBuffer {
+    fun getByteChunks(): ByteChunkBuffer {
         val unflushedFloats = chunkWrapped.position()
         if (unflushedFloats != 0) {
             buffer.addBytes(chunk.limit(unflushedFloats * BYTES_IN_A_FLOAT))
@@ -76,7 +76,7 @@ class FloatVectorBuffer(val dims: Int) {
             chunk = USELESS_BUFFER
             chunkWrapped = chunk.asFloatBuffer()
         }
-        return buffer.getByteBuffer()
+        return buffer
     }
 
     companion object {

--- a/src/main/kotlin/models/glTF/FloatVectorBuffer.kt
+++ b/src/main/kotlin/models/glTF/FloatVectorBuffer.kt
@@ -48,6 +48,22 @@ class FloatVectorBuffer(val dims: Int) {
         }
     }
 
+    fun add(x: Float, y: Float, z: Float) {
+        assert(pos == 0 && dims == 3)
+        chunkWrapped.put(x).put(y).put(z)
+
+        min[0] = min(min[0], x)
+        max[0] = max(max[0], x)
+        min[1] = min(min[1], y)
+        max[1] = max(max[1], y)
+        min[2] = min(min[2], z)
+        max[2] = max(max[2], z)
+
+        if ((chunkWrapped.position() + dims) * BYTES_IN_A_FLOAT > chunk.limit()) {
+            refreshBuffer()
+        }
+    }
+
     /** Retrieve the raw bytes from this buffer.
      *  Note that this buffer cannot be added to after this operation has taken place.
      */

--- a/src/main/kotlin/models/glTF/FloatVectorBuffer.kt
+++ b/src/main/kotlin/models/glTF/FloatVectorBuffer.kt
@@ -10,7 +10,7 @@ class FloatVectorBuffer(val dims: Int) {
     val min = FloatArray(dims) { Float.POSITIVE_INFINITY }
     val max = FloatArray(dims) { Float.NEGATIVE_INFINITY }
 
-    private val buffer = ByteChunkBuffer() // Steal our efficient byte-concat code
+    private val buffer = ByteChunkBuffer(ByteBuffer::allocate) // Steal our efficient byte-concat code
     private var chunk = newBuffer(INITIAL_CAPACITY)
     private var chunkWrapped = chunk.asFloatBuffer()
 

--- a/src/main/kotlin/models/glTF/FloatVectorBuffer.kt
+++ b/src/main/kotlin/models/glTF/FloatVectorBuffer.kt
@@ -23,7 +23,7 @@ class FloatVectorBuffer(val dims: Int) {
     private var bufferedSize = 0
 
     private fun newBuffer(capacity: Int): ByteBuffer =
-        ByteBuffer.allocateDirect(capacity).order(ByteOrder.LITTLE_ENDIAN)
+        ByteBuffer.allocate(capacity).order(ByteOrder.LITTLE_ENDIAN)
 
     private fun refreshBuffer() {
         val unflushedFloats = chunkWrapped.position()

--- a/src/main/kotlin/models/glTF/FloatVectorBuffer.kt
+++ b/src/main/kotlin/models/glTF/FloatVectorBuffer.kt
@@ -1,8 +1,8 @@
 package models.glTF
 
+import utils.ByteChunkBuffer
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
-import java.nio.FloatBuffer
 import kotlin.math.max
 import kotlin.math.min
 
@@ -10,7 +10,7 @@ class FloatVectorBuffer(val dims: Int) {
     val min = FloatArray(dims) { Float.POSITIVE_INFINITY }
     val max = FloatArray(dims) { Float.NEGATIVE_INFINITY }
 
-    private val buffer = Buffer("") // Steal our efficient byte-concat code
+    private val buffer = ByteChunkBuffer() // Steal our efficient byte-concat code
     private var chunk = newBuffer(INITIAL_CAPACITY)
     private var chunkWrapped = chunk.asFloatBuffer()
 

--- a/src/main/kotlin/models/glTF/MaterialBuffers.kt
+++ b/src/main/kotlin/models/glTF/MaterialBuffers.kt
@@ -26,16 +26,12 @@ class MaterialBuffers(isTextured: Boolean) {
         texcoordV: Float,
         rs2color: Int
     ) {
-        positions.add(positionX)
-        positions.add(-positionY)
-        positions.add(-positionZ)
+        positions.add(positionX, -positionY, -positionZ)
 
         if (colors != null) {
             val color = Color(pal[rs2color and 0xFFFF])
 
-            colors.add(color.red.toFloat() / 255f)
-            colors.add(color.green.toFloat() / 255f)
-            colors.add(color.blue.toFloat() / 255f)
+            colors.add(color.red.toFloat() / 255f, color.green.toFloat() / 255f, color.blue.toFloat() / 255f)
         }
 
         if (texcoords != null) {

--- a/src/main/kotlin/models/glTF/glTF.kt
+++ b/src/main/kotlin/models/glTF/glTF.kt
@@ -120,7 +120,9 @@ class glTF {
         buffers.add(buffer)
 
         // write buffer to files
-        File("$directory/${buffer.uri}").writeBytes(chunkBuffer.getBytes())
+        File("$directory/${buffer.uri}").outputStream().channel.use {
+            it.write(chunkBuffer.getByteBuffer())
+        }
 
         // convert to JSON
         val mapper = ObjectMapper()

--- a/src/main/kotlin/models/glTF/glTF.kt
+++ b/src/main/kotlin/models/glTF/glTF.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import utils.ByteChunkBuffer
 import java.io.File
+import java.nio.ByteBuffer
 import kotlin.math.max
 import kotlin.math.min
 
@@ -109,7 +110,7 @@ class glTF {
     }
 
     fun save(directory: String) {
-        val chunkBuffer = ByteChunkBuffer()
+        val chunkBuffer = ByteChunkBuffer(ByteBuffer::allocateDirect)
 
         for (materialId in materialMap.keys) {
             addMesh(materialId, chunkBuffer)

--- a/src/main/kotlin/models/glTF/glTF.kt
+++ b/src/main/kotlin/models/glTF/glTF.kt
@@ -62,13 +62,13 @@ class glTF {
         floatBuffer: FloatVectorBuffer,
         buffer: Buffer
     ): Int {
-        val floatsByteArray = floatBuffer.getBytes()
+        val floatsByteBuffer = floatBuffer.getBytes()
 
         // buffer view
-        val bufferView = BufferView(0, buffer.getByteLength(), floatsByteArray.size)
+        val bufferView = BufferView(0, buffer.getByteLength(), floatsByteBuffer.limit())
         bufferViews.add(bufferView)
 
-        buffer.addBytes(floatsByteArray)
+        buffer.addBytes(floatsByteBuffer)
 
         // accessor
         val accessorType = when (floatBuffer.dims) {

--- a/src/main/kotlin/models/glTF/glTF.kt
+++ b/src/main/kotlin/models/glTF/glTF.kt
@@ -5,8 +5,6 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import utils.ByteChunkBuffer
 import java.io.File
 import java.nio.ByteBuffer
-import kotlin.math.max
-import kotlin.math.min
 
 class glTF {
     val asset = Asset(
@@ -64,13 +62,13 @@ class glTF {
         floatBuffer: FloatVectorBuffer,
         buffer: ByteChunkBuffer
     ): Int {
-        val floatsByteBuffer = floatBuffer.getBytes()
+        val floatsByteChunkBuffer = floatBuffer.getByteChunks()
 
         // buffer view
-        val bufferView = BufferView(0, buffer.byteLength, floatsByteBuffer.limit())
+        val bufferView = BufferView(0, buffer.byteLength, floatsByteChunkBuffer.byteLength)
         bufferViews.add(bufferView)
 
-        buffer.addBytes(floatsByteBuffer)
+        buffer.addBytes(floatsByteChunkBuffer)
 
         // accessor
         val accessorType = when (floatBuffer.dims) {

--- a/src/main/kotlin/utils/ByteChunkBuffer.kt
+++ b/src/main/kotlin/utils/ByteChunkBuffer.kt
@@ -1,14 +1,17 @@
 package utils
 
 import java.nio.ByteBuffer
+import java.util.function.IntFunction
 
-class ByteChunkBuffer {
+class ByteChunkBuffer(private val factory: IntFunction<ByteBuffer>) {
     private val byteChunks = ArrayList<ByteBuffer>()
 
     val byteLength get() = byteChunks.sumOf { it.limit() }
 
     fun getByteBuffer(): ByteBuffer {
-        val finalBytes = ByteBuffer.allocateDirect(byteLength)
+        if (byteChunks.size == 1) return byteChunks[0].duplicate()
+
+        val finalBytes = factory.apply(byteLength)
         byteChunks.forEach { chunk ->
             finalBytes.put(chunk)
         }

--- a/src/main/kotlin/utils/ByteChunkBuffer.kt
+++ b/src/main/kotlin/utils/ByteChunkBuffer.kt
@@ -1,6 +1,5 @@
 package utils
 
-import com.fasterxml.jackson.annotation.JsonIgnore
 import java.nio.ByteBuffer
 
 class ByteChunkBuffer {
@@ -8,15 +7,6 @@ class ByteChunkBuffer {
 
     val byteLength get() = byteChunks.sumOf { it.limit() }
 
-    @JsonIgnore
-    fun getBytes(): ByteArray {
-        val buf = getByteBuffer()
-        val arr = ByteArray(buf.remaining())
-        buf.get(arr)
-        return arr
-    }
-
-    @JsonIgnore
     fun getByteBuffer(): ByteBuffer {
         val finalBytes = ByteBuffer.allocateDirect(byteLength)
         byteChunks.forEach { chunk ->

--- a/src/main/kotlin/utils/ByteChunkBuffer.kt
+++ b/src/main/kotlin/utils/ByteChunkBuffer.kt
@@ -1,0 +1,36 @@
+package utils
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import java.nio.ByteBuffer
+
+class ByteChunkBuffer {
+    private val byteChunks = ArrayList<ByteBuffer>()
+
+    val byteLength get() = byteChunks.sumOf { it.limit() }
+
+    @JsonIgnore
+    fun getBytes(): ByteArray {
+        val buf = getByteBuffer()
+        val arr = ByteArray(buf.remaining())
+        buf.get(arr)
+        return arr
+    }
+
+    @JsonIgnore
+    fun getByteBuffer(): ByteBuffer {
+        val finalBytes = ByteBuffer.allocateDirect(byteLength)
+        byteChunks.forEach { chunk ->
+            finalBytes.put(chunk)
+        }
+        finalBytes.flip()
+
+        // Might as well cache the fruit of our efforts
+        byteChunks.clear()
+        byteChunks.add(finalBytes.duplicate())
+        return finalBytes
+    }
+
+    fun addBytes(bytesToAdd: ByteBuffer) {
+        byteChunks.add(bytesToAdd)
+    }
+}

--- a/src/main/kotlin/utils/ByteChunkBuffer.kt
+++ b/src/main/kotlin/utils/ByteChunkBuffer.kt
@@ -26,4 +26,8 @@ class ByteChunkBuffer(private val factory: IntFunction<ByteBuffer>) {
     fun addBytes(bytesToAdd: ByteBuffer) {
         byteChunks.add(bytesToAdd)
     }
+
+    fun addBytes(byteChunks: ByteChunkBuffer) {
+        this.byteChunks.addAll(byteChunks.byteChunks)
+    }
 }


### PR DESCRIPTION
Makes the initial area export consistently take ~~about 4-9% less time on my machine :^)~~ idk it goes faster, measurements are changing as I go

~~The difference for larger exports is a little more fine unfortunately~~