### PR TITLE
Fix chunk stacking when renderer is dead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
   - Fix position and rotation of wall-attached objects (shields, coats of arms, windows, torches, etc.).
   - Add normal-merged lighting algorithm, removing the pillow-shaded effect some tiles erroneously had.
 
+- Fix chunk stacking in export when the preview is not working &ndash; [#108](https://github.com/ConnorDY/OSRS-Environment-Exporter/pull/108) (reported in [#104](https://github.com/ConnorDY/OSRS-Environment-Exporter/issues/104)) @ScoreUnder
+
 ### :wrench: Maintenance
 
 - Optimise glTF export a little &ndash; [#96](https://github.com/ConnorDY/OSRS-Environment-Exporter/pull/96) @ScoreUnder

--- a/src/main/kotlin/controllers/worldRenderer/Renderer.kt
+++ b/src/main/kotlin/controllers/worldRenderer/Renderer.kt
@@ -444,16 +444,14 @@ class Renderer(
             if (visible) {
                 for (x in 0 until scene.cols * REGION_SIZE) {
                     for (y in 0 until scene.rows * REGION_SIZE) {
-                        scene.getTile(z, x, y)?.let { drawTile(it) }
+                        scene.getTile(z, x, y)?.let { drawTile(it, x, y) }
                     }
                 }
             }
         }
     }
 
-    private fun drawTile(tile: SceneTile) {
-        val x: Int = tile.x
-        val y: Int = tile.y
+    private fun drawTile(tile: SceneTile, x: Int, y: Int) {
         val tilePaint = tile.tilePaint
         if (tilePaint != null) {
             priorityRenderer.positionRenderable(

--- a/src/main/kotlin/controllers/worldRenderer/SceneExporter.kt
+++ b/src/main/kotlin/controllers/worldRenderer/SceneExporter.kt
@@ -9,6 +9,7 @@ import controllers.worldRenderer.entities.TilePaint
 import models.DebugOptionsModel
 import models.glTF.MaterialBuffers
 import models.glTF.glTF
+import models.scene.REGION_SIZE
 import models.scene.Scene
 import models.scene.SceneTile
 import java.io.File
@@ -42,12 +43,16 @@ class SceneExporter constructor(private val textureManager: TextureManager, priv
         for (rx in 0 until scene.cols) {
             for (ry in 0 until scene.rows) {
                 val region = scene.getRegion(rx, ry) ?: continue
+                val baseX = rx * REGION_SIZE
+                val baseY = ry * REGION_SIZE
                 renderer.zLevelsSelected.forEachIndexed { z, visible ->
                     if (visible) {
-                        for (x in 0 until 64) {
-                            for (y in 0 until 64) {
-                                val tile = region.tiles[z][x][y] ?: continue
-                                this.upload(gltf, tile)
+                        val tilePlane = region.tiles[z]
+                        for (x in 0 until REGION_SIZE) {
+                            val tileCol = tilePlane[x]
+                            for (y in 0 until REGION_SIZE) {
+                                val tile = tileCol[y] ?: continue
+                                this.upload(gltf, tile, baseX + x, baseY + y)
                             }
                         }
                     }
@@ -87,9 +92,7 @@ class SceneExporter constructor(private val textureManager: TextureManager, priv
         }
     }
 
-    private fun upload(gltf: glTF, tile: SceneTile) {
-        val x = tile.x
-        val y = tile.y
+    private fun upload(gltf: glTF, tile: SceneTile, x: Int, y: Int) {
         if (debugOptionsModel.showTilePaint.value.get()) {
             tile.tilePaint?.let { upload(gltf, it, x, y, 0) }
         }

--- a/src/main/kotlin/models/scene/Scene.kt
+++ b/src/main/kotlin/models/scene/Scene.kt
@@ -96,13 +96,7 @@ class Scene(
         val region = getRegion(gridX, gridY) ?: return null
         val regionX: Int = x % REGION_SIZE
         val regionY: Int = y % REGION_SIZE
-        val tile: SceneTile? = region.tiles[z][regionX][regionY]
-        if (tile != null) {
-            // offset the tile by adding its scene offset to its region offset - get scene position
-            tile.x = regionX + gridX * REGION_SIZE
-            tile.y = regionY + gridY * REGION_SIZE
-        }
-        return tile
+        return region.tiles[z][regionX][regionY]
     }
 
     fun getRegion(gridX: Int, gridY: Int): SceneRegion? {

--- a/src/main/kotlin/models/scene/SceneRegion.kt
+++ b/src/main/kotlin/models/scene/SceneRegion.kt
@@ -236,7 +236,7 @@ class SceneRegion(val locationsDefinition: LocationsDefinition) {
     private fun ensureTile(z: Int, x: Int, y: Int): SceneTile {
         for (iz in z downTo 0) {
             if (tiles[iz][x][y] == null) {
-                tiles[iz][x][y] = SceneTile(iz, x, y)
+                tiles[iz][x][y] = SceneTile()
             }
         }
         return tiles[z][x][y]!!

--- a/src/main/kotlin/models/scene/SceneTile.kt
+++ b/src/main/kotlin/models/scene/SceneTile.kt
@@ -12,8 +12,7 @@ import controllers.worldRenderer.entities.WallDecoration
 import controllers.worldRenderer.entities.WallObject
 import kotlin.collections.ArrayList
 
-class SceneTile(val z: Int, var x: Int, var y: Int) {
-
+class SceneTile {
     var locations: ArrayList<Location> = ArrayList()
     var cacheTile: RegionDefinition.Tile? = null
     var overlayDefinition: OverlayDefinition? = null


### PR DESCRIPTION
This removes the x/y/z info from a SceneTile, since that's relative to
a scene and it's more expensive to update it in the tile than it is to
just pass it around.

The issue was ultimately caused by the x and y coordinates of a
SceneTile being mutable, and not being set at a time when they were
expected to be.

Fix #104