### PR TITLE
Remove some leftover code that makes model concat slightly incorrect

### DIFF
--- a/src/main/kotlin/cache/definitions/ModelDefinition.kt
+++ b/src/main/kotlin/cache/definitions/ModelDefinition.kt
@@ -401,7 +401,6 @@ open class ModelDefinition(
         }
 
         private fun concatIndices(first: ShortArray, second: ShortArray, shift: Int): ShortArray {
-            val shift = first.size
             return first + second.map { (it + shift).toShort() }
         }
 


### PR DESCRIPTION
This hasn't ever caused a problem because the result of this specific
part of the concatenation is ultimately unused, but it's nice to have
the algorithm correct.