### PR TITLE
Stop animation timer on MainController dispose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Upcoming
+
+### :bug: Bug Fixes
+
+- Fix a potential process lingering issue when the renderer fails to load &ndash; [#119](https://github.com/ConnorDY/OSRS-Environment-Exporter/pull/119) @ScoreUnder
+
 ## 2.2.0
 
 ### :sparkles: Enhancements

--- a/src/main/kotlin/controllers/MainController.kt
+++ b/src/main/kotlin/controllers/MainController.kt
@@ -224,6 +224,11 @@ class MainController constructor(
         }
     }
 
+    override fun dispose() {
+        super.dispose()
+        animationTimer.stop()
+    }
+
     private fun changeRegionClicked(event: ActionEvent) {
         RegionChooserController(
             this, "Region Chooser"


### PR DESCRIPTION
This makes the process less likely to linger if the renderer doesn't
spawn.
As for why that only happens when the renderer doesn't spawn, I couldn't
say.