### PR TITLE
Scale canvas to proper width/height even under high-DPI scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Fix a potential process lingering issue when the renderer fails to load &ndash; [#119](https://github.com/ConnorDY/OSRS-Environment-Exporter/pull/119) @ScoreUnder
 
+- Scale canvas correctly even under high-DPI modes &ndash; [#125](https://github.com/ConnorDY/OSRS-Environment-Exporter/pull/125) @ScoreUnder
+
 ## 2.2.0
 
 ### :sparkles: Enhancements

--- a/src/main/kotlin/controllers/worldRenderer/Renderer.kt
+++ b/src/main/kotlin/controllers/worldRenderer/Renderer.kt
@@ -81,6 +81,7 @@ import org.lwjgl.opengl.GL40C.glMinSampleShading
 import org.lwjgl.opengl.awt.AWTGLCanvas
 import org.lwjgl.opengl.awt.GLData
 import org.slf4j.LoggerFactory
+import utils.Utils.isMacOS
 import java.awt.event.ActionListener
 import java.awt.event.ComponentAdapter
 import java.awt.event.ComponentEvent
@@ -169,7 +170,12 @@ class Renderer(
             }
 
             override fun paintGL() {
-                this@Renderer.reshape(framebufferWidth, framebufferHeight)
+                if (isMacOS()) {
+                    // MacOS highDPI stuff returns the wrong value for framebuffer width/height
+                    this@Renderer.reshape(width, height)
+                } else {
+                    this@Renderer.reshape(framebufferWidth, framebufferHeight)
+                }
                 if (width > 0 && height > 0)
                     this@Renderer.display(this)
             }

--- a/src/main/kotlin/controllers/worldRenderer/Renderer.kt
+++ b/src/main/kotlin/controllers/worldRenderer/Renderer.kt
@@ -169,7 +169,7 @@ class Renderer(
             }
 
             override fun paintGL() {
-                this@Renderer.reshape(0, 0, width, height)
+                this@Renderer.reshape(framebufferWidth, framebufferHeight)
                 if (width > 0 && height > 0)
                     this@Renderer.display(this)
             }
@@ -282,12 +282,12 @@ class Renderer(
         pendingGlThreadActions.add(thing)
     }
 
-    fun reshape(x: Int, y: Int, width: Int, height: Int) {
+    fun reshape(width: Int, height: Int) {
         canvasWidth = width
         canvasHeight = height
         camera.centerX = canvasWidth / 2
         camera.centerY = canvasHeight / 2
-        glViewport(x, y, width, height)
+        glViewport(0, 0, width, height)
     }
 
     var isSceneUploadRequired = true


### PR DESCRIPTION
Fix #122 

Requires testing on

- [X] Linux, normal DPI
- [X] Linux, high DPI
- [x] Windows, normal DPI
- [x] Windows, high DPI
- [ ] MacOS, whatever you can get lmao I don't know if you can turn it off and on