### PR TITLE
Fix texture brightness changing between exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 
 - Allow the user to specify a wider range of region IDs (our initial assumptions were too restrictive) &ndash; [#136](https://github.com/ConnorDY/OSRS-Environment-Exporter/pull/136) @ScoreUnder
 
+- Fixed texture brightness changing between multiple exports in the same session &ndash; [#138](https://github.com/ConnorDY/OSRS-Environment-Exporter/pull/138) @ScoreUnder
+
 ## 2.2.0
 
 ### :sparkles: Enhancements

--- a/src/main/kotlin/cache/definitions/TextureDefinition.kt
+++ b/src/main/kotlin/cache/definitions/TextureDefinition.kt
@@ -23,7 +23,7 @@ class TextureDefinition {
             val var7: SpriteDefinition = spriteLoader.get(fileIds[var6]) ?: return false
             var7.normalize()
             val var8: ByteArray = var7.pixelIdx
-            val var9: IntArray = var7.palette
+            val var9: IntArray = var7.palette.clone()
             val var10 = field1786[var6]
             var var11: Int
             var var12: Int


### PR DESCRIPTION
The textures in the texture directory would brighten themselves every time they were exported. This means if you're up to your 5th export of the session, the textures will start looking noticeably washed-out.