### PR TITLE
Remove double-precision floats from shaders

### DIFF
--- a/src/main/kotlin/controllers/worldRenderer/GLSLPriorityRenderer.kt
+++ b/src/main/kotlin/controllers/worldRenderer/GLSLPriorityRenderer.kt
@@ -54,7 +54,7 @@ class GLSLPriorityRenderer() : AbstractPriorityRenderer() {
     private val glSmallComputeProgram = Shader.COMPUTE_PROGRAM.value.compile(Shader.createTemplate(512, 1))
     private val glUnorderedComputeProgram = Shader.UNORDERED_COMPUTE_PROGRAM.value.compile(Shader.createTemplate(-1, -1))
 
-    private val uniformBuffer: ByteBuffer = BufferUtils.createByteBuffer(5 * Double.SIZE_BYTES + (3 + 1) * Int.SIZE_BYTES)
+    private val uniformBuffer: ByteBuffer = BufferUtils.createByteBuffer(5 * Float.SIZE_BYTES + (3 + 1) * Int.SIZE_BYTES)
     private val uniformBufferId = initUniformBuffer(uniformBuffer)
 
     private val uniBlockSmall = glGetUniformBlockIndex(glSmallComputeProgram, "uniforms")
@@ -156,14 +156,14 @@ class GLSLPriorityRenderer() : AbstractPriorityRenderer() {
         // UBO
         glBindBuffer(GL_UNIFORM_BUFFER, uniformBufferId)
         uniformBuffer.clear()
-        val doubles = uniformBuffer.asDoubleBuffer()
+        val doubles = uniformBuffer.asFloatBuffer()
         doubles
-            .put(camera.yawRads)
-            .put(camera.pitchRads)
-            .put(camera.cameraX) // x
-            .put(camera.cameraZ) // z
-            .put(camera.cameraY) // y
-        val doublesPosition = doubles.position() * Double.SIZE_BYTES
+            .put(camera.yawRads.toFloat())
+            .put(camera.pitchRads.toFloat())
+            .put(camera.cameraX.toFloat()) // x
+            .put(camera.cameraZ.toFloat()) // z
+            .put(camera.cameraY.toFloat()) // y
+        val doublesPosition = doubles.position() * Float.SIZE_BYTES
         uniformBuffer.position(doublesPosition)
         val ints = uniformBuffer.asIntBuffer()
         ints

--- a/src/main/kotlin/controllers/worldRenderer/Renderer.kt
+++ b/src/main/kotlin/controllers/worldRenderer/Renderer.kt
@@ -124,7 +124,7 @@ class Renderer(
 
     private var textureArrayId = 0
     private var uniformBufferId = 0
-    private val uniformBuffer: ByteBuffer = BufferUtils.createByteBuffer(5 * Double.SIZE_BYTES + (3 + 1) * Int.SIZE_BYTES)
+    private val uniformBuffer: ByteBuffer = BufferUtils.createByteBuffer(5 * Float.SIZE_BYTES + (3 + 1) * Int.SIZE_BYTES)
     private val textureOffsets = FloatArray(256)
 
     private lateinit var priorityRenderer: PriorityRenderer
@@ -441,15 +441,15 @@ class Renderer(
         // UBO
         glBindBuffer(GL_UNIFORM_BUFFER, uniformBufferId)
         uniformBuffer.clear()
-        val doubles = uniformBuffer.asDoubleBuffer()
+        val doubles = uniformBuffer.asFloatBuffer()
         doubles
-            .put(camera.yawRads)
-            .put(camera.pitchRads)
-            .put(camera.cameraX) // x
-            .put(camera.cameraZ) // z
-            .put(camera.cameraY) // y
+            .put(camera.yawRads.toFloat())
+            .put(camera.pitchRads.toFloat())
+            .put(camera.cameraX.toFloat()) // x
+            .put(camera.cameraZ.toFloat()) // z
+            .put(camera.cameraY.toFloat()) // y
         // Ints
-        val doublesPosition = doubles.position() * Double.SIZE_BYTES
+        val doublesPosition = doubles.position() * Float.SIZE_BYTES
         uniformBuffer.position(doublesPosition)
         val ints = uniformBuffer.asIntBuffer()
         ints

--- a/src/main/resources/gpu/common.glsl
+++ b/src/main/resources/gpu/common.glsl
@@ -78,12 +78,9 @@ bool face_visible(ivec4 vA, ivec4 vB, ivec4 vC, ivec4 position) {
   vB += position - cameraPos;
   vC += position - cameraPos;
 
-  float yawf = float(cameraYaw);
-  float pitchf = float(cameraPitch);
-
-  vec3 sA = toScreen(vA.xyz, yawf, pitchf, centerX, centerY, zoom);
-  vec3 sB = toScreen(vB.xyz, yawf, pitchf, centerX, centerY, zoom);
-  vec3 sC = toScreen(vC.xyz, yawf, pitchf, centerX, centerY, zoom);
+  vec3 sA = toScreen(vA.xyz, cameraYaw, cameraPitch, centerX, centerY, zoom);
+  vec3 sB = toScreen(vB.xyz, cameraYaw, cameraPitch, centerX, centerY, zoom);
+  vec3 sC = toScreen(vC.xyz, cameraYaw, cameraPitch, centerX, centerY, zoom);
 
   return (sA.x - sB.x) * (sC.y - sB.y) - (sC.x - sB.x) * (sA.y - sB.y) > 0;
 }

--- a/src/main/resources/gpu/comp.glsl
+++ b/src/main/resources/gpu/comp.glsl
@@ -65,11 +65,8 @@ void main() {
   ivec4 vB[FACES_PER_THREAD];
   ivec4 vC[FACES_PER_THREAD];
 
-  float yawf = float(cameraYaw);
-  float pitchf = float(cameraPitch);
-
   for (int i = 0; i < FACES_PER_THREAD; i++) {
-    get_face(localId + i, minfo, yawf, pitchf, prio[i], dis[i], vA[i], vB[i], vC[i]);
+    get_face(localId + i, minfo, cameraYaw, cameraPitch, prio[i], dis[i], vA[i], vB[i], vC[i]);
   }
 
   memoryBarrierShared();

--- a/src/main/resources/gpu/comp_common.glsl
+++ b/src/main/resources/gpu/comp_common.glsl
@@ -27,11 +27,11 @@
 #define UNIT PI / 1024.0f
 
 layout(std140) uniform uniforms {
-    double cameraYaw;
-    double cameraPitch;
-    double cameraX;
-    double cameraY;
-    double cameraZ;
+    float cameraYaw;
+    float cameraPitch;
+    float cameraX;
+    float cameraY;
+    float cameraZ;
     int centerX;
     int centerY;
     int zoom;

--- a/src/main/resources/gpu/uniforms.glsl
+++ b/src/main/resources/gpu/uniforms.glsl
@@ -1,9 +1,9 @@
 layout(std140) uniform uniforms {
-    double cameraYaw;
-    double cameraPitch;
-    double cameraX;
-    double cameraY;
-    double cameraZ;
+    float cameraYaw;
+    float cameraPitch;
+    float cameraX;
+    float cameraY;
+    float cameraZ;
     int centerX;
     int centerY;
     int zoom;

--- a/src/main/resources/gpu/vert.glsl
+++ b/src/main/resources/gpu/vert.glsl
@@ -47,7 +47,6 @@ void main()
 
     vec3 rgb = hslToRgb(hsl);
 
-    ivec3 cameraPos = ivec3(cameraX, cameraY, cameraZ);
     gl_Position = viewProjectionMatrix * vec4(vertex, 1);
     Color = vec4(rgb, 1.f - a);
     fHsl = float(hsl);


### PR DESCRIPTION
Like https://github.com/ConnorDY/OSRS-Environment-Exporter/pull/145 but doing away with them entirely since the version of GLSL we target doesn't necessarily always support them