### PR TITLE
Add configurable scale factor for export; default to 1:128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### :sparkles: Enhancements
 
-- Add custom scale factors and default to 1:128 instead of 1:100 &ndash;
+- Add custom scale factors and default to 1:128 instead of 1:100 &ndash; [#177](https://github.com/ConnorDY/OSRS-Environment-Exporter/pull/177) @ScoreUnder
 
 ## 2.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### :sparkles: Enhancements
+
+- Add custom scale factors and default to 1:128 instead of 1:100 &ndash;
+
 ## 2.4.1
 
 ### :bug: Bug Fixes

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ java --version
 | `power-saving-mode`        | `Boolean` | `false`          | If enabled, will attempt to keep the idle frame rate as low as possible without impacting usability.                                                                                                         |
 | `priority-renderer`        | `Enum`    | Varies           | The face-sorting renderer to use. May not actually sort faces. One of `GLSL`, `CPU_NAIVE`. Set to `CPU_NAIVE` on MacOS due to missing compute shader support, and `GLSL` everywhere else.                    |
 | `sample-shading`           | `Boolean` | `false`          | If enabled, tells OpenGL to shade sub-samples in MSAA (OpenGL 4.0+).                                                                                                                                         |
+| `scale-mode`               | `Enum`    | `SCALE_1TO128`   | The scaling mode to use. One of `SCALE_1TO1`, `SCALE1TO100`, `SCALE_1TO128`. See also `--scale`.                                                                                                             |
 
 ## Development
 

--- a/src/main/kotlin/App.kt
+++ b/src/main/kotlin/App.kt
@@ -134,6 +134,7 @@ fun main(args: Array<String>) {
                             return
                         }
                         startupOptions.scaleFactor = scaleNumerator / scaleDenominator
+                        startupOptions.hasScaleFactor = true
                     } catch (e: NumberFormatException) {
                         println("Error: Invalid scale: $scale")
                         return

--- a/src/main/kotlin/App.kt
+++ b/src/main/kotlin/App.kt
@@ -53,6 +53,7 @@ private fun printHelp() {
     println("  --export-dir <path>   Set the export directory for this run")
     println("  --flat, -f            Do not use timestamped subdirectories for export")
     println("  --format <format>     Set the export format for this run")
+    println("  --scale <factor>      Set the export scale factor (e.g. 1:128), overrides config")
     println("  --no-preview          Run the GUI, but don't render the preview")
     println("  --                    End of options")
     println()
@@ -111,6 +112,30 @@ fun main(args: Array<String>) {
                     // Placeholder for when we actually support multiple export formats
                     if (formatName != "gltf") {
                         println("Error: Unknown export format: $formatName")
+                        return
+                    }
+                }
+                "--scale" -> {
+                    if (args.size < 2) {
+                        println("Error: --scale requires an argument")
+                        return
+                    }
+                    val scale = args[++argIndex]
+                    val scaleParts = scale.split(":")
+                    if (scaleParts.size != 2) {
+                        println("Error: Invalid scale: $scale")
+                        return
+                    }
+                    try {
+                        val scaleNumerator = scaleParts[0].trim().toFloat()
+                        val scaleDenominator = scaleParts[1].trim().toFloat()
+                        if (scaleNumerator == 0f || scaleDenominator == 0f) {
+                            println("Error: Invalid scale: $scale")
+                            return
+                        }
+                        startupOptions.scaleFactor = scaleNumerator / scaleDenominator
+                    } catch (e: NumberFormatException) {
+                        println("Error: Invalid scale: $scale")
                         return
                     }
                 }

--- a/src/main/kotlin/CliExporter.kt
+++ b/src/main/kotlin/CliExporter.kt
@@ -50,7 +50,12 @@ class CliExporter(startupOptions: StartupOptions) {
 
         scene.sceneChangeListeners.add {
             // Export the scene once it has been loaded.
-            exporter.exportSceneToFile(scene, startupOptions.exportDir, startupOptions.exportFlat)
+            val scaleFactor =
+                if (startupOptions.hasScaleFactor)
+                    startupOptions.scaleFactor
+                else
+                    startupOptions.defaultScaleFactor
+            exporter.exportSceneToFile(scene, startupOptions.exportDir, startupOptions.exportFlat, scaleFactor)
         }
 
         // Listen for progress updates

--- a/src/main/kotlin/CliExporter.kt
+++ b/src/main/kotlin/CliExporter.kt
@@ -50,12 +50,12 @@ class CliExporter(startupOptions: StartupOptions) {
 
         scene.sceneChangeListeners.add {
             // Export the scene once it has been loaded.
-            val scaleFactor =
-                if (startupOptions.hasScaleFactor)
-                    startupOptions.scaleFactor
-                else
-                    startupOptions.defaultScaleFactor
-            exporter.exportSceneToFile(scene, startupOptions.exportDir, startupOptions.exportFlat, scaleFactor)
+            exporter.exportSceneToFile(
+                scene,
+                startupOptions.exportDir,
+                startupOptions.exportFlat,
+                startupOptions.scaleFactor
+            )
         }
 
         // Listen for progress updates

--- a/src/main/kotlin/controllers/main/MainController.kt
+++ b/src/main/kotlin/controllers/main/MainController.kt
@@ -299,7 +299,12 @@ class MainController constructor(
         Thread {
             try {
                 try {
-                    exporter.exportSceneToFile(scene, startupOptions.exportDir, startupOptions.exportFlat)
+                    val scaleFactor =
+                        if (startupOptions.hasScaleFactor)
+                            startupOptions.scaleFactor
+                        else
+                            configOptions.scaleMode.value.get().scaleFactor
+                    exporter.exportSceneToFile(scene, startupOptions.exportDir, startupOptions.exportFlat, scaleFactor)
                 } catch (_: CancelledException) {
                     return@Thread
                 }

--- a/src/main/kotlin/controllers/worldRenderer/SceneExporter.kt
+++ b/src/main/kotlin/controllers/worldRenderer/SceneExporter.kt
@@ -26,7 +26,7 @@ class SceneExporter(private val textureManager: TextureManager, private val debu
     val chunkWriteListeners = ArrayList<ChunkWriteListener>()
     var sceneId = (System.currentTimeMillis() / 1000L).toInt()
 
-    fun exportSceneToFile(scene: Scene, directory: String, exportFlat: Boolean) {
+    fun exportSceneToFile(scene: Scene, directory: String, exportFlat: Boolean, scale: Float) {
         // create output directory if it does not yet exist
         File(directory).mkdirs()
 
@@ -37,7 +37,7 @@ class SceneExporter(private val textureManager: TextureManager, private val debu
         File(outDir).mkdirs()
 
         // init glTF builder
-        val fmt = GlTFExporter(outDir, chunkWriteListeners)
+        val fmt = GlTFExporter(outDir, scale, chunkWriteListeners)
 
         ++sceneId
 
@@ -157,40 +157,40 @@ class SceneExporter(private val textureManager: TextureManager, private val debu
             val x = tileX * Constants.LOCAL_TILE_SIZE
             val z = tileY * Constants.LOCAL_TILE_SIZE
             materialBuffer.addVertex(
-                (vertexAx + x).toFloat() / scale,
-                (neHeight + height).toFloat() / scale,
-                (vertexAy + z).toFloat() / scale,
+                (vertexAx + x).toFloat(),
+                (neHeight + height).toFloat(),
+                (vertexAy + z).toFloat(),
                 1f, 1f, neColor
             )
             materialBuffer.addVertex(
-                (vertexBx + x).toFloat() / scale,
-                (nwHeight + height).toFloat() / scale,
-                (vertexBy + z).toFloat() / scale,
+                (vertexBx + x).toFloat(),
+                (nwHeight + height).toFloat(),
+                (vertexBy + z).toFloat(),
                 0f, 1f, nwColor
             )
             materialBuffer.addVertex(
-                (vertexCx + x).toFloat() / scale,
-                (seHeight + height).toFloat() / scale,
-                (vertexCy + z).toFloat() / scale,
+                (vertexCx + x).toFloat(),
+                (seHeight + height).toFloat(),
+                (vertexCy + z).toFloat(),
                 1f, 0f, seColor
             )
 
             materialBuffer.addVertex(
-                (vertexDx + x).toFloat() / scale,
-                (swHeight + height).toFloat() / scale,
-                (vertexDy + z).toFloat() / scale,
+                (vertexDx + x).toFloat(),
+                (swHeight + height).toFloat(),
+                (vertexDy + z).toFloat(),
                 0f, 0f, swColor
             )
             materialBuffer.addVertex(
-                (vertexCx + x).toFloat() / scale,
-                (seHeight + height).toFloat() / scale,
-                (vertexCy + z).toFloat() / scale,
+                (vertexCx + x).toFloat(),
+                (seHeight + height).toFloat(),
+                (vertexCy + z).toFloat(),
                 1f, 0f, seColor
             )
             materialBuffer.addVertex(
-                (vertexBx + x).toFloat() / scale,
-                (nwHeight + height).toFloat() / scale,
-                (vertexBy + z).toFloat() / scale,
+                (vertexBx + x).toFloat(),
+                (nwHeight + height).toFloat(),
+                (vertexBy + z).toFloat(),
                 0f, 1f, nwColor
             )
         }
@@ -236,25 +236,25 @@ class SceneExporter(private val textureManager: TextureManager, private val debu
                 val materialBuffer = fmt.getMaterialBuffersAndAddTexture(textureId)
 
                 materialBuffer.addVertex(
-                    (vertexXA + x).toFloat() / scale,
-                    (vertexY[triangleA] + height).toFloat() / scale,
-                    (vertexZA + z).toFloat() / scale,
+                    (vertexXA + x).toFloat(),
+                    (vertexY[triangleA] + height).toFloat(),
+                    (vertexZA + z).toFloat(),
                     vertexXA.toFloat() / 128.0f,
                     vertexZA.toFloat() / 128.0f,
                     colorA
                 )
                 materialBuffer.addVertex(
-                    (vertexXB + x).toFloat() / scale,
-                    (vertexY[triangleB] + height).toFloat() / scale,
-                    (vertexZB + z).toFloat() / scale,
+                    (vertexXB + x).toFloat(),
+                    (vertexY[triangleB] + height).toFloat(),
+                    (vertexZB + z).toFloat(),
                     vertexXB.toFloat() / 128.0f,
                     vertexZB.toFloat() / 128.0f,
                     colorB
                 )
                 materialBuffer.addVertex(
-                    (vertexXC + x).toFloat() / scale,
-                    (vertexY[triangleC] + height).toFloat() / scale,
-                    (vertexZC + z).toFloat() / scale,
+                    (vertexXC + x).toFloat(),
+                    (vertexY[triangleC] + height).toFloat(),
+                    (vertexZC + z).toFloat(),
                     vertexXC.toFloat() / 128.0f,
                     vertexZC.toFloat() / 128.0f,
                     colorC
@@ -334,32 +334,31 @@ class SceneExporter(private val textureManager: TextureManager, private val debu
         val materialBuffer = fmt.getMaterialBuffersAndAddTexture(textureId)
 
         materialBuffer.addVertex(
-            (vertexX[triangleA] + x).toFloat() / scale,
-            (vertexY[triangleA] + height).toFloat() / scale,
-            (vertexZ[triangleA] + z).toFloat() / scale,
+            (vertexX[triangleA] + x).toFloat(),
+            (vertexY[triangleA] + height).toFloat(),
+            (vertexZ[triangleA] + z).toFloat(),
             uv[uvIdx], uv[uvIdx + 1],
             alpha or priority or color1
         )
 
         materialBuffer.addVertex(
-            (vertexX[triangleB] + x).toFloat() / scale,
-            (vertexY[triangleB] + height).toFloat() / scale,
-            (vertexZ[triangleB] + z).toFloat() / scale,
+            (vertexX[triangleB] + x).toFloat(),
+            (vertexY[triangleB] + height).toFloat(),
+            (vertexZ[triangleB] + z).toFloat(),
             uv[uvIdx + 2], uv[uvIdx + 3],
             alpha or priority or color2
         )
 
         materialBuffer.addVertex(
-            (vertexX[triangleC] + x).toFloat() / scale,
-            (vertexY[triangleC] + height).toFloat() / scale,
-            (vertexZ[triangleC] + z).toFloat() / scale,
+            (vertexX[triangleC] + x).toFloat(),
+            (vertexY[triangleC] + height).toFloat(),
+            (vertexZ[triangleC] + z).toFloat(),
             uv[uvIdx + 4], uv[uvIdx + 5],
             alpha or priority or color3
         )
     }
 
     companion object {
-        const val scale = 100f
         val fakeUvArray = floatArrayOf(0f, 0f, 0f, 0f, 0f, 0f)
     }
 }

--- a/src/main/kotlin/models/StartupOptions.kt
+++ b/src/main/kotlin/models/StartupOptions.kt
@@ -11,7 +11,6 @@ class StartupOptions(configOptions: ConfigOptions) {
     var exportDir = OUTPUT_DIRECTORY
     var exportFlat = false
     var showPreview = true
-    var scaleFactor = 0f
-    val hasScaleFactor get() = scaleFactor != 0f
-    val defaultScaleFactor = configOptions.scaleMode.value.get().scaleFactor
+    var scaleFactor = configOptions.scaleMode.value.get().scaleFactor
+    var hasScaleFactor = false
 }

--- a/src/main/kotlin/models/StartupOptions.kt
+++ b/src/main/kotlin/models/StartupOptions.kt
@@ -11,4 +11,7 @@ class StartupOptions(configOptions: ConfigOptions) {
     var exportDir = OUTPUT_DIRECTORY
     var exportFlat = false
     var showPreview = true
+    var scaleFactor = 0f
+    val hasScaleFactor get() = scaleFactor != 0f
+    val defaultScaleFactor = configOptions.scaleMode.value.get().scaleFactor
 }

--- a/src/main/kotlin/models/config/ConfigOptions.kt
+++ b/src/main/kotlin/models/config/ConfigOptions.kt
@@ -2,6 +2,7 @@ package models.config
 
 import controllers.worldRenderer.helpers.AlphaMode
 import controllers.worldRenderer.helpers.AntiAliasingMode
+import models.config.types.ScaleMode
 import utils.Utils.isMacOS
 import controllers.worldRenderer.Renderer.PreferredPriorityRenderer as PriorityRenderers
 
@@ -20,6 +21,7 @@ class ConfigOptions(private val configuration: Configuration) {
     val alphaMode = ConfigOption("alpha-mode", ConfigOptionType.Enumerated(AlphaMode::valueOf, AlphaMode.values(), AlphaMode::humanReadableName), AlphaMode.ORDERED_DITHER, "Alpha mode", 'L')
     val sampleShading = ConfigOption("sample-shading", ConfigOptionType.boolean, false, "Sub-sample shading (GL4.0; makes hashed alpha look nicer)", 'S')
     val fov = ConfigOption("fov", ConfigOptionType.double, 90.0, "Field of view (degrees)", 'V')
+    val scaleMode = ConfigOption("scale-mode", ConfigOptionType.Enumerated(ScaleMode::valueOf, ScaleMode.values(), ScaleMode::humanReadableName), ScaleMode.SCALE_1TO128, "Export scale", 'C')
 
     val isMacOS = isMacOS()
 
@@ -27,6 +29,7 @@ class ConfigOptions(private val configuration: Configuration) {
         lastCacheDir,
         initialRegionId,
         initialRadius,
+        scaleMode,
         fpsCap,
         powerSavingMode,
         checkForUpdates,

--- a/src/main/kotlin/models/config/types/ScaleMode.kt
+++ b/src/main/kotlin/models/config/types/ScaleMode.kt
@@ -1,0 +1,7 @@
+package models.config.types
+
+enum class ScaleMode(val humanReadableName: String, val scaleFactor: Float) {
+    SCALE_1TO1("1:1 (Internal cache size, giant!)", 1f),
+    SCALE_1TO100("1:100 (Previous default)", 1f / 100f),
+    SCALE_1TO128("1:128 (1 tile per unit)", 1f / 128f),
+}

--- a/src/main/kotlin/models/formats/GlTFExporter.kt
+++ b/src/main/kotlin/models/formats/GlTFExporter.kt
@@ -19,7 +19,7 @@ import utils.ByteChunkBuffer
 import utils.ChunkWriteListener
 import java.io.File
 
-class GlTFExporter(private val directory: String, private val chunkWriteListeners: List<ChunkWriteListener>) : MeshFormatExporter {
+class GlTFExporter(private val directory: String, private val scale: Float, private val chunkWriteListeners: List<ChunkWriteListener>) : MeshFormatExporter {
     private val materialMap = HashMap<Int, MaterialBuffers>()
     private val rsIndexToMaterialIndex = HashMap<Int, Int>()
     private val sceneNodes = ArrayList<Int>()
@@ -94,7 +94,7 @@ class GlTFExporter(private val directory: String, private val chunkWriteListener
     }
 
     override fun getOrCreateBuffersForMaterial(materialId: Int) = materialMap.getOrPut(materialId) {
-        MaterialBuffers(materialId >= 0)
+        MaterialBuffers(materialId >= 0, scale)
     }
 
     override fun addTextureMaterial(rsIndex: Int, imagePath: String) {

--- a/src/main/kotlin/models/formats/MaterialBuffers.kt
+++ b/src/main/kotlin/models/formats/MaterialBuffers.kt
@@ -3,7 +3,7 @@ package models.formats
 import cache.utils.ColorPalette
 import java.awt.Color
 
-class MaterialBuffers(isTextured: Boolean) {
+class MaterialBuffers(isTextured: Boolean, private val scale: Float) {
     val positions = FloatVectorBuffer(3)
     val texcoords: FloatVectorBuffer?
     val colors: FloatVectorBuffer?
@@ -26,7 +26,7 @@ class MaterialBuffers(isTextured: Boolean) {
         texcoordV: Float,
         rs2color: Int
     ) {
-        positions.add(positionX, -positionY, -positionZ)
+        positions.add(positionX * scale, -positionY * scale, -positionZ * scale)
 
         if (colors != null) {
             val color = Color(pal[rs2color and 0xFFFF])


### PR DESCRIPTION
This lets the user choose whether they want 1:1 (Qodat-style), 1:100 (Old default), or 1:128 (default as of this PR, gives a 1 tile per unit export). It also allows this to be overridden on the command line via the `--scale` parameter.