### PR TITLE
Bump version to 2.4.1 in run scripts

### DIFF
--- a/run
+++ b/run
@@ -26,4 +26,7 @@ if [ "${1#--debug}" != "$1" ]; then
     shift
 fi
 
-exec "$java" $debug_params -jar ./build/libs/osrs-environment-exporter-fat-2.3.0.jar "$@"
+# Get the appropriate version from build.gradle.kts
+version=$(grep -oP '(?<=version = ").*(?=")' build.gradle.kts)
+
+exec "$java" $debug_params -jar ./build/libs/osrs-environment-exporter-fat-$version.jar "$@"

--- a/run.bat
+++ b/run.bat
@@ -1,2 +1,2 @@
 @echo off
-java -jar ./build/libs/osrs-environment-exporter-fat-2.3.0.jar %*
+java -jar ./build/libs/osrs-environment-exporter-fat-2.4.1.jar %*


### PR DESCRIPTION
No changelog as this is a minor change

Still not sure how I would go about this in Windows, and WINE's batch support (especially with regexes in findstr) doesn't seem to be up to scratch.