### PR TITLE
Allow Z-layer selection on command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Add custom scale factors and default to 1:128 instead of 1:100 &ndash; [#177](https://github.com/ConnorDY/OSRS-Environment-Exporter/pull/177) @ScoreUnder
 
+- Add command line option to select Z layers &ndash; [#181](https://github.com/ConnorDY/OSRS-Environment-Exporter/pull/181) @ScoreUnder
+
 ## 2.4.1
 
 ### :bug: Bug Fixes

--- a/src/main/kotlin/App.kt
+++ b/src/main/kotlin/App.kt
@@ -1,3 +1,4 @@
+import cache.definitions.RegionDefinition.Companion.Z
 import controllers.CacheChooserController
 import models.StartupOptions
 import models.config.ConfigOptions
@@ -55,6 +56,7 @@ private fun printHelp() {
     println("  --format <format>     Set the export format for this run")
     println("  --scale <factor>      Set the export scale factor (e.g. 1:128), overrides config")
     println("  --no-preview          Run the GUI, but don't render the preview")
+    println("  --z-layers <layers>   Set the Z layers to render (e.g. 0,1,2,3)")
     println("  --                    End of options")
     println()
     println("Arguments:")
@@ -142,6 +144,25 @@ fun main(args: Array<String>) {
                 }
                 "--no-preview" -> {
                     startupOptions.showPreview = false
+                }
+                "--z-layers" -> {
+                    if (args.size < 2) {
+                        println("Error: --z-layers requires an argument")
+                        return
+                    }
+                    val zLayers = args[++argIndex]
+                    val zLayerParts = zLayers.split(",")
+                    val zLayersList = try {
+                        zLayerParts.map { it.trim().toInt() }
+                    } catch (e: NumberFormatException) {
+                        println("Error: List of Z layers should contain only numbers: $zLayers")
+                        return
+                    }
+                    if (zLayersList.any { it < 0 || it >= Z }) {
+                        println("Error: All Z layers should be in the range 0-${Z - 1}: $zLayers")
+                        return
+                    }
+                    startupOptions.enabledZLayers = zLayersList
                 }
                 "--" -> {
                     argIndex++

--- a/src/main/kotlin/App.kt
+++ b/src/main/kotlin/App.kt
@@ -86,7 +86,7 @@ fun main(args: Array<String>) {
                     configOptions.debug.value.set(true)
                 }
                 "--cache-dir" -> {
-                    if (args.size < 2) {
+                    if (args.size - argIndex < 2) {
                         println("Error: --cache-dir requires an argument")
                         return
                     }
@@ -96,7 +96,7 @@ fun main(args: Array<String>) {
                     startupOptions.exportOnly = true
                 }
                 "--export-dir" -> {
-                    if (args.size < 2) {
+                    if (args.size - argIndex < 2) {
                         println("Error: --export-dir requires an argument")
                         return
                     }
@@ -106,7 +106,7 @@ fun main(args: Array<String>) {
                     startupOptions.exportFlat = true
                 }
                 "--format" -> {
-                    if (args.size < 2) {
+                    if (args.size - argIndex < 2) {
                         println("Error: --format requires an argument")
                         return
                     }
@@ -118,7 +118,7 @@ fun main(args: Array<String>) {
                     }
                 }
                 "--scale" -> {
-                    if (args.size < 2) {
+                    if (args.size - argIndex < 2) {
                         println("Error: --scale requires an argument")
                         return
                     }
@@ -146,7 +146,7 @@ fun main(args: Array<String>) {
                     startupOptions.showPreview = false
                 }
                 "--z-layers" -> {
-                    if (args.size < 2) {
+                    if (args.size - argIndex < 2) {
                         println("Error: --z-layers requires an argument")
                         return
                     }

--- a/src/main/kotlin/App.kt
+++ b/src/main/kotlin/App.kt
@@ -11,6 +11,7 @@ import javax.swing.SwingUtilities
 import javax.swing.ToolTipManager
 import javax.swing.UIManager
 import javax.swing.UnsupportedLookAndFeelException
+import kotlin.system.exitProcess
 
 private fun setSysProperty(key: String, value: String) {
     if (System.getProperty(key) == null) {
@@ -64,6 +65,11 @@ private fun printHelp() {
     println("  radius                The radius of regions to load")
 }
 
+private fun errorExit(message: String): Nothing {
+    System.err.println("Error: $message")
+    exitProcess(1)
+}
+
 fun main(args: Array<String>) {
     val configOptions = ConfigOptions(Configuration())
     val startupOptions = StartupOptions(configOptions)
@@ -87,8 +93,7 @@ fun main(args: Array<String>) {
                 }
                 "--cache-dir" -> {
                     if (args.size - argIndex < 2) {
-                        println("Error: --cache-dir requires an argument")
-                        return
+                        errorExit("--cache-dir requires an argument")
                     }
                     startupOptions.cacheDir = args[++argIndex]
                 }
@@ -97,8 +102,7 @@ fun main(args: Array<String>) {
                 }
                 "--export-dir" -> {
                     if (args.size - argIndex < 2) {
-                        println("Error: --export-dir requires an argument")
-                        return
+                        errorExit("--export-dir requires an argument")
                     }
                     startupOptions.exportDir = args[++argIndex]
                 }
@@ -107,39 +111,33 @@ fun main(args: Array<String>) {
                 }
                 "--format" -> {
                     if (args.size - argIndex < 2) {
-                        println("Error: --format requires an argument")
-                        return
+                        errorExit("--format requires an argument")
                     }
                     val formatName = args[++argIndex]
                     // Placeholder for when we actually support multiple export formats
                     if (formatName != "gltf") {
-                        println("Error: Unknown export format: $formatName")
-                        return
+                        errorExit("Unknown export format: $formatName")
                     }
                 }
                 "--scale" -> {
                     if (args.size - argIndex < 2) {
-                        println("Error: --scale requires an argument")
-                        return
+                        errorExit("--scale requires an argument")
                     }
                     val scale = args[++argIndex]
                     val scaleParts = scale.split(":")
                     if (scaleParts.size != 2) {
-                        println("Error: Invalid scale: $scale")
-                        return
+                        errorExit("Invalid scale: $scale")
                     }
                     try {
                         val scaleNumerator = scaleParts[0].trim().toFloat()
                         val scaleDenominator = scaleParts[1].trim().toFloat()
                         if (scaleNumerator == 0f || scaleDenominator == 0f) {
-                            println("Error: Invalid scale: $scale")
-                            return
+                            errorExit("Invalid scale: $scale")
                         }
                         startupOptions.scaleFactor = scaleNumerator / scaleDenominator
                         startupOptions.hasScaleFactor = true
                     } catch (e: NumberFormatException) {
-                        println("Error: Invalid scale: $scale")
-                        return
+                        errorExit("Invalid scale: $scale")
                     }
                 }
                 "--no-preview" -> {
@@ -147,20 +145,17 @@ fun main(args: Array<String>) {
                 }
                 "--z-layers" -> {
                     if (args.size - argIndex < 2) {
-                        println("Error: --z-layers requires an argument")
-                        return
+                        errorExit("--z-layers requires an argument")
                     }
                     val zLayers = args[++argIndex]
                     val zLayerParts = zLayers.split(",")
                     val zLayersList = try {
                         zLayerParts.map { it.trim().toInt() }
                     } catch (e: NumberFormatException) {
-                        println("Error: List of Z layers should contain only numbers: $zLayers")
-                        return
+                        errorExit("List of Z layers should contain only numbers: $zLayers")
                     }
                     if (zLayersList.any { it < 0 || it >= Z }) {
-                        println("Error: All Z layers should be in the range 0-${Z - 1}: $zLayers")
-                        return
+                        errorExit("All Z layers should be in the range 0-${Z - 1}: $zLayers")
                     }
                     startupOptions.enabledZLayers = zLayersList
                 }
@@ -171,8 +166,7 @@ fun main(args: Array<String>) {
 
                 else -> {
                     if (arg.startsWith("-")) {
-                        println("Error: Unknown option '$arg'")
-                        return
+                        errorExit("Unknown option '$arg'")
                     } else {
                         // Positional argument, pass downwards
                         break
@@ -184,8 +178,7 @@ fun main(args: Array<String>) {
 
         // We should have 2 arguments left: region ID and radius. Anything else is an error.
         if (args.size - argIndex > 2) {
-            println("Error: Too many arguments")
-            return
+            errorExit("Too many arguments")
         }
 
         if (argIndex < args.size) {

--- a/src/main/kotlin/CliExporter.kt
+++ b/src/main/kotlin/CliExporter.kt
@@ -40,6 +40,7 @@ class CliExporter(startupOptions: StartupOptions) {
         val modelLoader = ModelLoader(cacheLibrary)
 
         val debugOptionsModel = DebugOptionsModel()
+        debugOptionsModel.setZLevelsFromList(startupOptions.enabledZLayers)
 
         val textureManager = TextureManager(spriteLoader, textureLoader)
         val objectToModelConverter = ObjectToModelConverter(modelLoader, debugOptionsModel)

--- a/src/main/kotlin/controllers/main/MainController.kt
+++ b/src/main/kotlin/controllers/main/MainController.kt
@@ -85,6 +85,8 @@ class MainController constructor(
         layout = BorderLayout()
         preferredSize = Dimension(1600, 800)
 
+        debugOptions.setZLevelsFromList(startupOptions.enabledZLayers)
+
         val camera = Camera()
         val objectToModelConverter =
             ObjectToModelConverter(ModelLoader(cacheLibrary), debugOptions)

--- a/src/main/kotlin/models/DebugOptionsModel.kt
+++ b/src/main/kotlin/models/DebugOptionsModel.kt
@@ -17,4 +17,10 @@ class DebugOptionsModel {
     val all = listOf(showOnlyModelType, showTilePaint, showTileModels, resetCameraOnSceneChange, removeProperlyTypedModels, modelSubIndex, badModelIndexOverride)
 
     val zLevelsSelected = Array(Z) { true }.map(::ObservableValue)
+
+    fun setZLevelsFromList(enabledZLayers: List<Int>) {
+        zLevelsSelected.forEachIndexed { index, value ->
+            value.set(index in enabledZLayers)
+        }
+    }
 }

--- a/src/main/kotlin/models/StartupOptions.kt
+++ b/src/main/kotlin/models/StartupOptions.kt
@@ -1,6 +1,7 @@
 package models
 
 import AppConstants.OUTPUT_DIRECTORY
+import cache.definitions.RegionDefinition.Companion.Z
 import models.config.ConfigOptions
 
 class StartupOptions(configOptions: ConfigOptions) {
@@ -13,5 +14,5 @@ class StartupOptions(configOptions: ConfigOptions) {
     var showPreview = true
     var scaleFactor = configOptions.scaleMode.value.get().scaleFactor
     var hasScaleFactor = false
-    var enabledZLayers = (0..3).toList()
+    var enabledZLayers = (0 until Z).toList()
 }

--- a/src/main/kotlin/models/StartupOptions.kt
+++ b/src/main/kotlin/models/StartupOptions.kt
@@ -13,4 +13,5 @@ class StartupOptions(configOptions: ConfigOptions) {
     var showPreview = true
     var scaleFactor = configOptions.scaleMode.value.get().scaleFactor
     var hasScaleFactor = false
+    var enabledZLayers = (0..3).toList()
 }


### PR DESCRIPTION
Implementing #180, this allows the user to provide a list of Z layers to enable on the command line, e.g. `./run --z-layers 0,1`
