### PR TITLE
Were unable to load newer cache's, rev 230. Added fix to avoid buffer…

### DIFF
--- a/src/main/kotlin/cache/loaders/OverlayLoader.kt
+++ b/src/main/kotlin/cache/loaders/OverlayLoader.kt
@@ -29,6 +29,7 @@ import cache.ConfigType
 import cache.IndexType
 import cache.definitions.OverlayDefinition
 import cache.utils.read24BitInt
+import cache.utils.readString
 import cache.utils.readUnsignedByte
 import com.displee.cache.CacheLibrary
 import java.nio.ByteBuffer
@@ -59,6 +60,14 @@ class OverlayLoader(cacheLibrary: CacheLibrary) {
             } else if (opcode == 7) {
                 val secondaryColor: Int = inputStream.read24BitInt()
                 def.secondaryRgbColor = secondaryColor
+            } else if (opcode == 8) {
+                // Handle opcode 8 introduced in newer cache revisions
+                // Read string to prevent BufferUnderflowException
+                inputStream.readString()
+            } else {
+                // Handle unknown opcodes by skipping a single byte
+                // This prevents BufferUnderflowException when encountering new opcodes
+                inputStream.readUnsignedByte()
             }
         }
         def.calculateHsl()

--- a/src/main/kotlin/cache/loaders/OverlayLoader.kt
+++ b/src/main/kotlin/cache/loaders/OverlayLoader.kt
@@ -61,13 +61,7 @@ class OverlayLoader(cacheLibrary: CacheLibrary) {
                 val secondaryColor: Int = inputStream.read24BitInt()
                 def.secondaryRgbColor = secondaryColor
             } else if (opcode == 8) {
-                // Handle opcode 8 introduced in newer cache revisions
-                // Read string to prevent BufferUnderflowException
                 inputStream.readString()
-            } else {
-                // Handle unknown opcodes by skipping a single byte
-                // This prevents BufferUnderflowException when encountering new opcodes
-                inputStream.readUnsignedByte()
             }
         }
         def.calculateHsl()


### PR DESCRIPTION
Fix for loading newer cache's with rev 230 that resulted in this error:
Exception in thread "AWT-EventQueue-0" java.nio.BufferUnderflowException
        at java.base/java.nio.Buffer.nextGetIndex(Buffer.java:643)
        at java.base/java.nio.HeapByteBuffer.get(HeapByteBuffer.java:165)
        at cache.utils.ByteBufferExtKt.readUnsignedByte(ByteBufferExt.kt:29)
        at cache.loaders.OverlayLoader.load(OverlayLoader.kt:47)
        at cache.loaders.OverlayLoader.<init>(OverlayLoader.kt:73)
        at controllers.main.MainController.<init>(MainController.kt:93)

Now able to load them as normal.

Found solution based on https://github.com/dennisdev/rs-map-viewer/commit/dd102bcca1bf2cce445d075ddb867b3b129f3f3a

