### PR TITLE
Fix textures and random woman-NPC-bottom-half objects in caches >= v234

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,6 +64,11 @@ ktlint {
     ignoreFailures = true
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_19
+    targetCompatibility = JavaVersion.VERSION_19
+}
+
 tasks {
     withType<KotlinCompile> {
         kotlinOptions.jvmTarget = "19"

--- a/src/main/kotlin/CliExporter.kt
+++ b/src/main/kotlin/CliExporter.kt
@@ -31,7 +31,7 @@ class CliExporter(startupOptions: StartupOptions) {
         paramsManager.loadFromPath(startupOptions.cacheDir)
 
         val spriteLoader = SpriteLoader(cacheLibrary)
-        val textureLoader = TextureLoader(cacheLibrary)
+        val textureLoader = TextureLoader(cacheLibrary, paramsManager)
         val regionLoader = RegionLoader(cacheLibrary, paramsManager)
         val locationsLoader = LocationsLoader(cacheLibrary, xteaManager)
         val objectLoader = ObjectLoader(cacheLibrary)
@@ -44,7 +44,8 @@ class CliExporter(startupOptions: StartupOptions) {
 
         val textureManager = TextureManager(spriteLoader, textureLoader)
         val objectToModelConverter = ObjectToModelConverter(modelLoader, debugOptionsModel)
-        val sceneRegionBuilder = SceneRegionBuilder(regionLoader, locationsLoader, objectLoader, underlayLoader, overlayLoader, objectToModelConverter)
+        val sceneRegionBuilder =
+            SceneRegionBuilder(regionLoader, locationsLoader, objectLoader, underlayLoader, overlayLoader, objectToModelConverter)
 
         scene = Scene(sceneRegionBuilder, debugOptionsModel)
         exporter = SceneExporter(textureManager, debugOptionsModel)

--- a/src/main/kotlin/cache/loaders/ObjectLoader.kt
+++ b/src/main/kotlin/cache/loaders/ObjectLoader.kt
@@ -246,6 +246,9 @@ class ObjectLoader(private val cacheLibrary: CacheLibrary) : ThreadsafeLazyLoade
             }
             transforms[length + 1] = transform
             def.transforms = transforms
+        } else if (opcode == 95) {
+            logger.debug("Processed ignored opcode 95 for $def")
+            inputStream.readUnsignedByte()
         } else if (opcode == 249) {
             val length: Int = inputStream.readUnsignedByte()
             val params: MutableMap<Int, Any> = java.util.HashMap(length)

--- a/src/main/kotlin/controllers/main/MainController.kt
+++ b/src/main/kotlin/controllers/main/MainController.kt
@@ -92,7 +92,7 @@ class MainController constructor(
             ObjectToModelConverter(ModelLoader(cacheLibrary), debugOptions)
         val overlayLoader = OverlayLoader(cacheLibrary)
         val regionLoader = RegionLoader(cacheLibrary, paramsManager)
-        val textureLoader = TextureLoader(cacheLibrary)
+        val textureLoader = TextureLoader(cacheLibrary, paramsManager)
         val underlayLoader = UnderlayLoader(cacheLibrary)
 
         scene = Scene(


### PR DESCRIPTION
Not my finest work. The texture loading algorithm is a complete guess based on the vague shape of the data, but hey apparently it works.

We were also getting a warning about an unknown opcode 95, which caused random woman-NPC-bottom-half models to appear in random places on the map. Ignoring this opcode and the byte following it removed those extra models, so it was probably just a direct result of our input stream being 1 byte too early sometimes.

I haven't really done an in-depth dive into either of these unfortunately, I've just tweaked enough to get things to work.