### PR TITLE
Fix macOS preview rendering and menu handling

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,17 +11,7 @@ group = "link.cdy"
 version = "2.4.2"
 
 repositories {
-    mavenCentral {
-        content {
-            excludeModule("org.lwjglx", "lwjgl3-awt")
-        }
-    }
-    maven {
-        url = uri("https://score.moe/m2/")
-        metadataSources {
-            artifact()
-        }
-    }
+    mavenCentral()
 }
 
 dependencies {
@@ -40,7 +30,9 @@ dependencies {
     implementation("org.lwjgl", "lwjgl")
     implementation("org.lwjgl", "lwjgl-jawt")
     implementation("org.lwjgl", "lwjgl-opengl")
-    implementation("org.lwjglx", "lwjgl3-awt", "0.1.9-SNAPSHOT")
+    implementation("org.lwjglx", "lwjgl3-awt", "0.2.4") {
+        isTransitive = false
+    }
     implementation("org.joml", "joml", "1.10.4")
     testImplementation(kotlin("test"))
     for (

--- a/src/main/kotlin/App.kt
+++ b/src/main/kotlin/App.kt
@@ -5,6 +5,7 @@ import models.config.ConfigOptions
 import models.config.Configuration
 import org.pushingpixels.radiance.theming.api.skin.RadianceGraphiteAquaLookAndFeel
 import utils.PackageMetadata
+import utils.Utils.isMacOS
 import utils.Utils.isWindows
 import javax.swing.JPopupMenu
 import javax.swing.SwingUtilities
@@ -199,6 +200,9 @@ fun main(args: Array<String>) {
 fun setThemingOptions() {
     setSysProperty("awt.useSystemAAFontSettings", "on")
     setSysProperty("swing.aatext", "true")
+    if (isMacOS()) {
+        setSysProperty("apple.laf.useScreenMenuBar", "true")
+    }
 
     SwingUtilities.invokeLater {
         try {

--- a/src/main/kotlin/controllers/worldRenderer/Renderer.kt
+++ b/src/main/kotlin/controllers/worldRenderer/Renderer.kt
@@ -109,13 +109,19 @@ class Renderer(
 
             override fun paintGL() {
                 if (isMacOS()) {
-                    // MacOS highDPI stuff returns the wrong value for framebuffer width/height
-                    this@Renderer.reshape(width, height)
+                    val renderWidth = framebufferWidth.takeIf { it > 0 } ?: width
+                    val renderHeight = framebufferHeight.takeIf { it > 0 } ?: height
+
+                    this@Renderer.reshape(renderWidth, renderHeight)
+                    if (renderWidth > 0 && renderHeight > 0) {
+                        this@Renderer.display(this)
+                    }
                 } else {
                     this@Renderer.reshape(framebufferWidth, framebufferHeight)
+                    if (width > 0 && height > 0) {
+                        this@Renderer.display(this)
+                    }
                 }
-                if (width > 0 && height > 0)
-                    this@Renderer.display(this)
             }
 
             override fun disposeCanvas() {

--- a/src/main/kotlin/controllers/worldRenderer/Renderer.kt
+++ b/src/main/kotlin/controllers/worldRenderer/Renderer.kt
@@ -108,19 +108,14 @@ class Renderer(
             }
 
             override fun paintGL() {
-                if (isMacOS()) {
-                    val renderWidth = framebufferWidth.takeIf { it > 0 } ?: width
-                    val renderHeight = framebufferHeight.takeIf { it > 0 } ?: height
+                val renderWidth =
+                    if (isMacOS()) framebufferWidth.takeIf { it > 0 } ?: width else framebufferWidth
+                val renderHeight =
+                    if (isMacOS()) framebufferHeight.takeIf { it > 0 } ?: height else framebufferHeight
 
-                    this@Renderer.reshape(renderWidth, renderHeight)
-                    if (renderWidth > 0 && renderHeight > 0) {
-                        this@Renderer.display(this)
-                    }
-                } else {
-                    this@Renderer.reshape(framebufferWidth, framebufferHeight)
-                    if (width > 0 && height > 0) {
-                        this@Renderer.display(this)
-                    }
+                this@Renderer.reshape(renderWidth, renderHeight)
+                if (renderWidth > 0 && renderHeight > 0) {
+                    this@Renderer.display(this)
                 }
             }
 


### PR DESCRIPTION
## Summary
- update `lwjgl3-awt` to the stable `0.2.4` release from Maven Central
- fix macOS Retina preview sizing by preferring framebuffer dimensions when available
- move Swing menus to the macOS system menu bar so they stay accessible with the heavyweight GL canvas

## Details
The previous `lwjgl3-awt` snapshot was involved in macOS AWT OpenGL crashes. After updating the bridge dependency, the preview no longer crashed, but the embedded canvas rendered into the lower-left portion of the window on Retina displays and the menu bar became inaccessible.

This keeps the runtime workarounds scoped to macOS:
- `Renderer.paintGL()` uses framebuffer dimensions only on macOS, with a fallback to component size while the backing buffer is initializing
- `apple.laf.useScreenMenuBar` is only set on macOS

## Testing
- `./gradlew build`
- manual macOS verification of launch, preview rendering, and menu accessibility
